### PR TITLE
Part of fixes for generate tests on sail

### DIFF
--- a/integration-tests/c-example/lib/structures/simple_unions.h
+++ b/integration-tests/c-example/lib/structures/simple_unions.h
@@ -24,7 +24,7 @@ union SuperFloat {
 
 union Vector2D {
     int m[2];
-    struct Point /*make me anonymous*/{
+    struct {
         int x, y;
     };
 };

--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -541,9 +541,6 @@ Status Server::TestsGenServiceImpl::PrintModulesContent(ServerContext *context,
 
     MEASURE_FUNCTION_EXECUTION_TIME
 
-    fs::path compileCommandsJsonPath =
-        CompilationUtils::substituteRemotePathToCompileCommandsJsonPath(
-            request->projectpath(), request->builddirrelativepath());
     fs::path serverBuildDir = Paths::getTmpDir(request->projectname());
     utbot::ProjectContext projectContext{ *request };
     shared_ptr<BuildDatabase> buildDatabase = BuildDatabase::create(projectContext);

--- a/server/src/Tests.cpp
+++ b/server/src/Tests.cpp
@@ -365,7 +365,14 @@ shared_ptr<StructValueView> KTestObjectParser::structView(const vector<char> &by
                 throw NoSuchTypeException(message);
         }
     }
-    return std::make_shared<StructValueView>(subViews);
+
+    std::optional<std::string> entryValue;
+    if(curStruct.hasUnnamedFields) {
+        auto bytesType = types::Type::createSimpleTypeFromName("utbot_byte");
+        const shared_ptr<AbstractValueView> rawDataView = arrayView(byteArray, bytesType, curStruct.size, offset, usage);
+        entryValue = PrinterUtils::convertBytesToUnion(curStruct.name, rawDataView->getEntryValue());
+    }
+    return std::make_shared<StructValueView>(subViews, entryValue);
 }
 
 string KTestObjectParser::primitiveCharView(const types::Type &type, string value) {

--- a/server/src/environment/EnvironmentPaths.cpp
+++ b/server/src/environment/EnvironmentPaths.cpp
@@ -92,4 +92,8 @@ namespace Paths {
     fs::path getLdGold() {
         return getUTBotDebsInstallDir() / "usr" / "bin" / "ld.gold";
     }
+
+    fs::path getLd() {
+        return getUTBotDebsInstallDir() / "usr" / "bin" / "ld";
+    }
 }

--- a/server/src/environment/EnvironmentPaths.h
+++ b/server/src/environment/EnvironmentPaths.h
@@ -39,7 +39,9 @@ namespace Paths {
 
     fs::path getLdGold();
 
-    // Gcc is used only in tests
+    fs::path getLd();
+
+  // Gcc is used only in tests
     fs::path getGcc();
     fs::path getGpp();
 }

--- a/server/src/printers/NativeMakefilePrinter.h
+++ b/server/src/printers/NativeMakefilePrinter.h
@@ -48,9 +48,7 @@ namespace printer {
         void gtestMainTargets(const utbot::CompileCommand &defaultCompileCommand,
                               const fs::path &gtestBuildDir);
 
-        fs::path getSharedLibrary(const BuildDatabase::TargetInfo &linkUnitInfo,
-                                  BuildResult::Type unitType,
-                                  std::string const &suffixForParentOfStubs);
+        fs::path getSharedLibrary(const fs::path &filePath);
 
         void addTestTarget(const fs::path &sourcePath);
 

--- a/server/src/printers/Printer.cpp
+++ b/server/src/printers/Printer.cpp
@@ -192,6 +192,16 @@ namespace printer {
             } else {
                 if (paramTypes[i].isPointerToArray()) {
                     auto decomposedType = StringUtils::split(paramTypes[i].usedType(), '*');
+                    /*
+                     * code example
+                     * typedef int int_array[1];
+                     * int_array* int_array_pointer;
+                     * usedType == int_array*
+                     * mTypeName == int_array*[1]
+                     */
+                    if (decomposedType.size() != 2) {
+                        decomposedType = StringUtils::split(paramTypes[i].mTypeName(), '*');
+                    }
                     LOG_IF_S(ERROR, decomposedType.size() != 2) << "Type::isPointerToArray malfunction";
                     ss << decomposedType[0] << "*" << paramValues[i] << decomposedType[1];
                     named = true;

--- a/server/src/printers/TestsPrinter.cpp
+++ b/server/src/printers/TestsPrinter.cpp
@@ -372,11 +372,10 @@ void TestsPrinter::changeableParamsAsserts(const Tests::MethodDescription &metho
     auto assertsVisitor = visitor::VerboseAssertsParamVisitor(typesHandler, this);
     auto usage = types::PointerUsage::PARAMETER;
     size_t param_i = 0;
-    for (const auto& i : methodDescription.params) {
-        if (i.isChangeable()) {
-            auto const &param = i;
+    for (const auto& param : methodDescription.params) {
+        if (param.isChangeable()) {
             auto const &value = testCase.paramPostValues[param_i];
-            string expectedName = "expected_" + param.name;
+            string expectedName = PrinterUtils::getExpectedVarName(param.name);
             const types::Type expectedType = param.type.arrayCloneMultiDim(usage);
             parameterVisitor.visit(expectedType, expectedName, value.view.get(), std::nullopt);
             assertsVisitor.visit(param, param.name);
@@ -393,7 +392,7 @@ void TestsPrinter::globalParamsAsserts(const Tests::MethodDescription &methodDes
     for (size_t i = 0; i < methodDescription.globalParams.size(); i++) {
         auto const &param = methodDescription.globalParams[i];
         auto const &value = testCase.globalPostValues[i];
-        string expectedName = "expected_" + param.name;
+        string expectedName = PrinterUtils::getExpectedVarName(param.name);
         auto expectedType = typesHandler->getReturnTypeToCheck(param.type);
         Tests::MethodParam expectedParam{expectedType, expectedName, param.alignment};
         parameterVisitor.visit(expectedParam.type, expectedParam.name, value.view.get(), std::nullopt);

--- a/server/src/types/Types.cpp
+++ b/server/src/types/Types.cpp
@@ -101,6 +101,10 @@ types::Type types::Type::baseTypeObj() const {
     return baseTypeObj(getDimension());
 }
 
+std::string types::Type::mTypeName() const {
+    return this->mType;
+}
+
 size_t types::Type::getDimension() const {
     // usage doesn't matter here
     return arraysSizes(PointerUsage::PARAMETER).size();
@@ -291,6 +295,15 @@ bool types::Type::isConstQualifiedValue() const {
 bool types::Type::isTypeContainsPointer() const {
     for (const auto &kind : pointerArrayKinds()) {
         if (kind->getKind() == AbstractType::OBJECT_POINTER) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool types::Type::isTypeContainsFunctionPointer() const {
+    for (const auto &kind : mKinds) {
+        if (kind->getKind() == AbstractType::FUNCTION_POINTER) {
             return true;
         }
     }
@@ -863,7 +876,7 @@ types::TypesHandler::isSupportedType(const Type &type, TypeUsage usage, int dept
               }
               if (isStruct(type)) {
                   auto structInfo = getStructInfo(type);
-                  return unsupportedFields(structInfo.fields);
+                  return !structInfo.hasUnnamedFields && unsupportedFields(structInfo.fields);
               }
               return false;
             } },
@@ -919,7 +932,7 @@ types::TypesHandler::isSupportedType(const Type &type, TypeUsage usage, int dept
               };
               if (isStruct(type)) {
                   auto structInfo = getStructInfo(type);
-                  return unsupportedFields(structInfo.fields);
+                  return !structInfo.hasUnnamedFields && unsupportedFields(structInfo.fields);
               }
 
               if (isUnion(type)) {

--- a/server/src/types/Types.h
+++ b/server/src/types/Types.h
@@ -88,6 +88,12 @@ namespace types {
         [[nodiscard]] Type baseTypeObj() const;
 
         /**
+         * @return String mType
+         */
+        [[nodiscard]] std::string mTypeName() const;
+
+
+        /**
          * @return Type object where the first Kind is not a pointer, but an array
          */
         [[nodiscard]] Type arrayClone(PointerUsage usage, size_t pointerSize = 0) const;
@@ -178,9 +184,11 @@ namespace types {
          */
         [[nodiscard]] bool isConstQualifiedValue() const;
 
-        bool isTypeContainsPointer() const;
+        [[nodiscard]] bool isTypeContainsPointer() const;
 
-        int indexOfFirstPointerInTypeKinds() const;
+        [[nodiscard]] bool isTypeContainsFunctionPointer() const;
+
+        [[nodiscard]] int indexOfFirstPointerInTypeKinds() const;
 
         [[nodiscard]] std::vector<size_t> arraysSizes(PointerUsage usage) const;
 
@@ -271,10 +279,12 @@ namespace types {
         std::vector<Field> fields{};
 
         FPointerMap functionFields{};
+        bool hasUnnamedFields;
     };
 
     struct UnionInfo: TypeInfo {
         std::vector<Field> fields{};
+        bool hasUnnamedFields;
     };
 
     struct EnumInfo: TypeInfo {

--- a/server/src/types/TypesResolver.cpp
+++ b/server/src/types/TypesResolver.cpp
@@ -74,6 +74,7 @@ void TypesResolver::resolveStruct(const clang::RecordDecl *D, const std::string 
         sourceManager.getFilename(sourceManager.getSpellingLoc(D->getLocation())).str();
     structInfo.filePath = Paths::getCCJsonFileFullPath(filename, parent->buildRootPath);
     structInfo.name = name;
+    structInfo.hasUnnamedFields = false;
 
 
     if (Paths::isGtest(structInfo.filePath)) {
@@ -117,6 +118,7 @@ void TypesResolver::resolveStruct(const clang::RecordDecl *D, const std::string 
         if (LogUtils::isMaxVerbosity()) {
             ss << "\n\t" << field.type.typeName() << " " << field.name << ";";
         }
+        structInfo.hasUnnamedFields |= F->isAnonymousStructOrUnion();
         fields.push_back(field);
     }
     structInfo.fields = fields;
@@ -218,6 +220,7 @@ void TypesResolver::resolveUnion(const clang::RecordDecl *D, const std::string &
     ss << "Union: " << unionInfo.name << "\n"
        << "\tFile path: " << unionInfo.filePath.string() << "";
     std::vector<types::Field> fields;
+    unionInfo.hasUnnamedFields = false;
     for (const clang::FieldDecl *F : D->fields()) {
         types::Field field;
         string fieldName = F->getNameAsString();
@@ -228,6 +231,7 @@ void TypesResolver::resolveUnion(const clang::RecordDecl *D, const std::string &
         if (LogUtils::isMaxVerbosity()) {
             ss << "\n\t" << field.type.typeName() << " " << field.name << ";";
         }
+        unionInfo.hasUnnamedFields |= F->isAnonymousStructOrUnion();
         fields.push_back(field);
     }
     unionInfo.fields = fields;

--- a/server/src/utils/PrinterUtils.cpp
+++ b/server/src/utils/PrinterUtils.cpp
@@ -170,4 +170,7 @@ namespace PrinterUtils {
         return StringUtils::stringFormat("(%s%s)", StringUtils::repeat("*", depth), name);
     }
 
+    std::string getExpectedVarName(const std::string& varName) {
+        return "expected_" + varName;
+    }
 }

--- a/server/src/utils/PrinterUtils.h
+++ b/server/src/utils/PrinterUtils.h
@@ -47,6 +47,7 @@ namespace PrinterUtils {
 
     std::string getEqualString(const std::string& lhs, const std::string& rhs);
     std::string getDereferencePointer(const std::string& name, const size_t depth);
+    std::string getExpectedVarName(const std::string& varName);
 
     std::string initializePointer(const std::string &type, const std::string &value);
     std::string generateNewVar(int cnt);

--- a/server/src/visitors/VerboseAssertsParamVisitor.cpp
+++ b/server/src/visitors/VerboseAssertsParamVisitor.cpp
@@ -17,7 +17,7 @@ namespace visitor {
   static thread_local std::string expectedVariable;
 
   void VerboseAssertsParamVisitor::visit(const Tests::MethodParam &param, const std::string &name) {
-      expectedVariable = "expected_" + name;
+      expectedVariable = PrinterUtils::getExpectedVarName(name);
       string paramName = param.dataVariableName();
       types::Type paramType = param.type.arrayCloneMultiDim(usage);
       visitAny(paramType, paramName, nullptr, "", 0);
@@ -25,7 +25,7 @@ namespace visitor {
   }
 
   void VerboseAssertsParamVisitor::visitGlobal(const Tests::MethodParam &param, const std::string &name) {
-      expectedVariable = "expected_" + name;
+      expectedVariable = PrinterUtils::getExpectedVarName(name);
       visitAny(param.type, name, nullptr, "", 0);
       expectedVariable = {};
   }

--- a/server/test/suites/run/timeout/pregenerated_tests/main_test.cpp
+++ b/server/test/suites/run/timeout/pregenerated_tests/main_test.cpp
@@ -4,8 +4,11 @@
 
 #include "gtest/gtest.h"
 
+#include <chrono>
+#include <thread>
+
 namespace UTBot {
-    TEST(regression, endless_loop) {
-        while (true) {}
+    TEST(regression, two_minutes_test) {
+        std::this_thread::sleep_for(std::chrono::minutes(2));
     }
 }

--- a/server/test/suites/server/simple_unions.h
+++ b/server/test/suites/server/simple_unions.h
@@ -24,7 +24,7 @@ union SuperFloat {
 
 union Vector2D {
     int m[2];
-    struct Point /*make me anonymous*/{
+    struct {
         int x, y;
     };
 };

--- a/server/test/suites/syntax/CMakeLists.txt
+++ b/server/test/suites/syntax/CMakeLists.txt
@@ -33,4 +33,5 @@ add_executable(syntax1
         linked_list.c
         tree.c
         different_parameters.cpp
-        simple_class.cpp)
+        simple_class.cpp
+        inner_unnamed.c)

--- a/server/test/suites/syntax/inner_unnamed.c
+++ b/server/test/suites/syntax/inner_unnamed.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#include "inner_unnamed.h"
+
+struct StructWithUnnamedUnion struct_with_unnamed_union_as_return_type(char t) {
+    struct StructWithUnnamedUnion swuu;
+    swuu.x = t;
+    swuu.y = t;
+    return swuu;
+}
+
+struct StructWithUnnamedUnion struct_with_unnamed_union_as_parameter_type(struct StructWithUnnamedUnion swuu) {
+    if (swuu.x == 0 && swuu.y == 0) {
+        swuu.x = 42;
+        swuu.y = 42;
+        return swuu;
+    }
+    swuu.x = 24;
+    swuu.y = 24;
+    return swuu;
+}
+
+union UnionWithUnnamedStruct union_with_unnamed_struct_as_return_type(char t) {
+    union UnionWithUnnamedStruct uwus;
+    uwus.y = 0;
+    uwus.c = t;
+    uwus.x = t;
+    return uwus;
+}
+
+union UnionWithUnnamedStruct union_with_unnamed_struct_as_parameter_type(union UnionWithUnnamedStruct uwus) {
+    if (uwus.c == 0 && uwus.x == 0 && uwus.y == 0) {
+        uwus.y = 42;
+        uwus.c = 42;
+        uwus.x = 42;
+        return uwus;
+    }
+    uwus.y = 24;
+    uwus.c = 24;
+    uwus.x = 24;
+    return uwus;
+}

--- a/server/test/suites/syntax/inner_unnamed.h
+++ b/server/test/suites/syntax/inner_unnamed.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#ifndef UNITTESTBOT_INNER_UNNAMED_H
+#define UNITTESTBOT_INNER_UNNAMED_H
+
+struct StructWithUnnamedUnion {
+    union {
+        char c;
+        int x;
+    };
+
+    int y;
+};
+
+union UnionWithUnnamedStruct {
+    struct {
+        char c;
+        int x;
+    };
+
+    int y;
+};
+
+struct StructWithUnnamedUnion struct_with_unnamed_union_as_return_type(char t);
+
+struct StructWithUnnamedUnion struct_with_unnamed_union_as_parameter_type(struct StructWithUnnamedUnion swuu);
+
+union UnionWithUnnamedStruct union_with_unnamed_struct_as_return_type(char t);
+
+union UnionWithUnnamedStruct union_with_unnamed_struct_as_parameter_type(union UnionWithUnnamedStruct uwus);
+
+#endif //UNITTESTBOT_INNER_UNNAMED_H

--- a/server/test/suites/syntax/pointer_parameters.c
+++ b/server/test/suites/syntax/pointer_parameters.c
@@ -34,3 +34,14 @@ int pointer_as_array_parameter(int *a, int *b, int c) {
     *b = 4;
     return a[1] + *b + c;
 }
+
+typedef int int_array[1];
+
+int typedef_as_parameter_and_return(int_array* a) {
+    if((*a)[0] == 0) {
+        (*a)[0] = 42;
+    } else {
+        (*a)[0] = 24;
+    }
+    return (*a)[0];
+};

--- a/server/test/suites/syntax/simple_unions.h
+++ b/server/test/suites/syntax/simple_unions.h
@@ -24,7 +24,7 @@ union SuperFloat {
 
 union Vector2D {
     int m[2];
-    struct Point /*make me anonymous*/{
+    struct {
         int x, y;
     };
 };

--- a/server/test/suites/syntax/structs_with_pointers.c
+++ b/server/test/suites/syntax/structs_with_pointers.c
@@ -70,11 +70,10 @@ struct StructWithPointerInField some_calc(int a, int b) {
         st.a.a = 3;
         st.a.str = "CCC";
         return st;
-    } else {
-        st.ll = 0;
-        st.sh = 0;
-        st.a.a = 0;
-        st.a.str = "DDD";
-        return st;
     }
+    st.ll = 0;
+    st.sh = 0;
+    st.a.a = 0;
+    st.a.str = "DDD";
+    return st;
 }

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -469,6 +469,7 @@
 				"unittestbot.paths.buildDirectory": {
 					"type": "string",
 					"default": "build",
+					"minLength": 1,
 					"markdownDescription": "%unittestbot.paths.buildDirectory.description%"
 				},
 				"unittestbot.paths.cmakeOptions": {
@@ -479,6 +480,7 @@
 				"unittestbot.paths.testsDirectory": {
 					"type": "string",
 					"default": "tests",
+					"minLength": 1,
 					"markdownDescription": "%unittestbot.paths.testsDirectory.description%"
 				},
 				"unittestbot.paths.sourceDirectories": {


### PR DESCRIPTION
Add minimal limit of build and test path, compile exec into .o instead of .so, add support of inner unnamed into struct, set pointer to function as not changeable