### PR TITLE
Support projects where targets depend on installed libraries

### DIFF
--- a/server/src/Paths.cpp
+++ b/server/src/Paths.cpp
@@ -45,22 +45,18 @@ namespace Paths {
         return pathSet;
     }
     bool isSubPathOf(const fs::path &base, const fs::path &sub) {
-        auto b = normalizedTrimmed(base);
-        auto s = normalizedTrimmed(sub).parent_path();
-        auto m = std::mismatch(b.begin(), b.end(),
-                               s.begin(), s.end());
-        return m.first == b.end();
+        auto s = sub.parent_path();
+        auto m = std::mismatch(base.begin(), base.end(), s.begin(), s.end());
+        return m.first == base.end();
     }
 
     fs::path longestCommonPrefixPath(const fs::path &a, const fs::path &b) {
-        fs::path normalizedA = normalizedTrimmed(a);
-        fs::path normalizedB = normalizedTrimmed(b);
-        if (normalizedA == normalizedB) {
-            return normalizedA;
+        if (a == b) {
+            return a;
         }
-        auto const &[mismatchA, mismatchB] = std::mismatch(normalizedA.begin(), normalizedA.end(),
-                                                           normalizedB.begin(), normalizedB.end());
-        fs::path result = std::accumulate(normalizedA.begin(), mismatchA, fs::path{},
+        auto const &[mismatchA, mismatchB] = std::mismatch(a.begin(), a.end(), b.begin(), b.end());
+        fs::path result =
+            std::accumulate(a.begin(), mismatchA, fs::path{},
                             [](fs::path const &a, fs::path const &b) { return a / b; });
         return result;
     }

--- a/server/src/building/BuildDatabase.cpp
+++ b/server/src/building/BuildDatabase.cpp
@@ -51,6 +51,7 @@ BuildDatabase::BuildDatabase(const fs::path& buildCommandsJsonPath,
 
     createClangCompileCommandsJson(buildCommandsJsonPath, compileCommandsJson);
     initInfo(linkCommandsJson);
+    filterInstalledFiles();
     addLocalSharedLibraries();
     fillTargetInfoParents();
 }
@@ -222,11 +223,11 @@ void BuildDatabase::mergeLibraryOptions(std::vector<std::string> &jsonArguments)
 }
 
 namespace {
-    CollectionUtils::OrderedFileSet collectLibraryDirs(const utbot::BaseCommand *command) {
+    CollectionUtils::OrderedFileSet collectLibraryDirs(const utbot::BaseCommand &command) {
         using namespace DynamicLibraryUtils;
         CollectionUtils::OrderedFileSet libraryDirs;
-        for (string const &argument : command->getCommandLine()) {
-            auto optionalLibraryPath = getLibraryAbsolutePath(argument, command->getDirectory());
+        for (string const &argument : command.getCommandLine()) {
+            auto optionalLibraryPath = getLibraryAbsolutePath(argument, command.getDirectory());
             if (optionalLibraryPath.has_value()) {
                 libraryDirs.insert(optionalLibraryPath.value());
             }
@@ -248,13 +249,13 @@ namespace {
         return libraryDirs;
     }
 
-    CollectionUtils::MapFileTo<string> collectLibraryNames(const utbot::BaseCommand *command) {
+    CollectionUtils::MapFileTo<string> collectLibraryNames(const utbot::BaseCommand &command) {
         using namespace DynamicLibraryUtils;
 
         CollectionUtils::MapFileTo<string> libraryNames;
 
-        for (const auto &argument : command->getCommandLine()) {
-            if (Paths::isSharedLibraryFile(argument) && argument != command->getOutput() &&
+        for (const auto &argument : command.getCommandLine()) {
+            if (Paths::isSharedLibraryFile(argument) && argument != command.getOutput() &&
                 !StringUtils::startsWith(argument, libraryDirOptionWl)) {
                 libraryNames.emplace(argument, argument);
             }
@@ -270,12 +271,11 @@ namespace {
     }
 }
 
-template <typename Info>
-void BuildDatabase::addLibrariesForCommand(utbot::BaseCommand *command,
-                            const std::shared_ptr<Info> &info,
-                            sharedLibrariesMap &sharedLibraryFiles,
-                            bool objectFiles) {
-    if (command->isArchiveCommand()) {
+void BuildDatabase::addLibrariesForCommand(utbot::BaseCommand &command,
+                                           BaseFileInfo &info,
+                                           sharedLibrariesMap &sharedLibraryFiles,
+                                           bool objectFiles) {
+    if (command.isArchiveCommand()) {
         return;
     }
     auto libraryDirs = collectLibraryDirs(command);
@@ -291,16 +291,38 @@ void BuildDatabase::addLibrariesForCommand(utbot::BaseCommand *command,
             }
             fs::path fullPath = Paths::getCCJsonFileFullPath(name, libraryDir);
             if (CollectionUtils::containsKey(targetInfos, fullPath)) {
-                info->addFile(fullPath);
-                LOG_IF_S(WARNING, objectFiles) << "Object file " << command->getOutput() << " has library dependencies: " << fullPath;
+                info.addFile(fullPath);
+                LOG_IF_S(WARNING, objectFiles) << "Object file " << command.getOutput()
+                                               << " has library dependencies: " << fullPath;
                 argumentToFile[argument] = fullPath;
+            } else {
+                info.installedFiles.insert(fullPath);
             }
         }
     }
-    for (auto &argument : command->getCommandLine()) {
+    for (auto &argument : command.getCommandLine()) {
         if (CollectionUtils::containsKey(argumentToFile, argument)) {
             argument = argumentToFile[argument];
         }
+    }
+}
+
+void BuildDatabase::filterInstalledFiles() {
+    for (auto &it : targetInfos) {
+        auto &linkFile = it.first;
+        auto &targetInfo = it.second;
+        CollectionUtils::OrderedFileSet fileset;
+        targetInfo->installedFiles =
+            CollectionUtils::filterOut(targetInfo->files, [this](fs::path const &file) {
+                return CollectionUtils::containsKey(targetInfos, file) ||
+                       CollectionUtils::containsKey(objectFileInfos, file);
+            });
+        if (!targetInfo->installedFiles.empty()) {
+            LOG_S(DEBUG) << "Target " << linkFile << " depends on " << targetInfo->installedFiles.size() << " installed files";
+        }
+        CollectionUtils::erase_if(targetInfo->files, [&targetInfo](fs::path const &file) {
+            return CollectionUtils::contains(targetInfo->installedFiles, file);
+        });
     }
 }
 
@@ -314,11 +336,11 @@ void BuildDatabase::addLocalSharedLibraries() {
     }
     for (auto &[linkFile, targetInfo] : targetInfos) {
         for (auto &command : targetInfo->commands) {
-            addLibrariesForCommand(static_cast<utbot::BaseCommand*>(&command), targetInfo, sharedLibraryFiles);
+            addLibrariesForCommand(command, *targetInfo, sharedLibraryFiles);
         }
     }
     for (auto &[objectFile, objectInfo] : objectFileInfos) {
-        addLibrariesForCommand(static_cast<utbot::BaseCommand*>(&objectInfo->command), objectInfo, sharedLibraryFiles, true);
+        addLibrariesForCommand(objectInfo->command, *objectInfo, sharedLibraryFiles, true);
     }
 }
 

--- a/server/src/building/BuildDatabase.h
+++ b/server/src/building/BuildDatabase.h
@@ -40,16 +40,33 @@ public:
         bool allAreCorrect = false;
     };
 
+    struct BaseFileInfo {
+        BaseFileInfo() = default;
+        virtual ~BaseFileInfo() = default;
+
+        // Libraries that current command depends on, but those are already installed and not built
+        // within project
+        CollectionUtils::OrderedFileSet installedFiles;
+
+        virtual void addFile(fs::path file) = 0;
+    };
+
     /*
      * struct ObjectFileInfo represents a compile command from compile_commands.json
      * that produces an object file
      */
-    struct ObjectFileInfo {
-        utbot::CompileCommand command; // Compilation command
+    struct ObjectFileInfo : BaseFileInfo {
+        // Compilation command
+        utbot::CompileCommand command;
 
-        tsl::ordered_set<fs::path, HashUtils::PathHash> files; // Object files and libraries that current command depends on
-        fs::path linkUnit;                            // Example of executable or a library which contains current objectFile
-        std::shared_ptr<KleeFilesInfo> kleeFilesInfo; // Information about klee files
+        // Object files and libraries that current command depends on
+        CollectionUtils::OrderedFileSet files;
+
+        // Example of executable or a library which contains current objectFile
+        fs::path linkUnit;
+
+        // Information about klee files
+        std::shared_ptr<KleeFilesInfo> kleeFilesInfo;
 
         // Directory from where to execute the command
         [[nodiscard]] fs::path const &getDirectory() const;
@@ -60,7 +77,7 @@ public:
 
         void setOutputFile(const fs::path &file);
 
-        void addFile(fs::path file);
+        void addFile(fs::path file) override;
     };
 
     /*
@@ -69,17 +86,17 @@ public:
     * OR
     * a compile command from compile_commands.json that produces an executable
     */
-    struct TargetInfo {
-        //Linkage command
+    struct TargetInfo : BaseFileInfo {
+        // Linkage command
         std::vector<utbot::LinkCommand> commands;
 
         // Source files, object files and libraries that current command depends on
-        tsl::ordered_set<fs::path, HashUtils::PathHash> files;
+        CollectionUtils::OrderedFileSet files;
 
         // Units which contains current library
-        std::vector <fs::path> parentLinkUnits;
+        std::vector<fs::path> parentLinkUnits;
 
-        void addFile(fs::path file);
+        void addFile(fs::path file) override;
 
         // Executable or a library, the result of a command
         [[nodiscard]] fs::path getOutput() const;
@@ -202,6 +219,7 @@ private:
     static bool conflictPriorityMore(const std::shared_ptr<ObjectFileInfo> &left,
                                      const std::shared_ptr<ObjectFileInfo> &right);
 
+    void filterInstalledFiles();
     void addLocalSharedLibraries();
     void fillTargetInfoParents();
     static fs::path getCorrespondingBitcodeFile(const fs::path &filepath);
@@ -215,9 +233,8 @@ private:
 
     using sharedLibrariesMap = std::unordered_map<std::string, CollectionUtils::MapFileTo<fs::path>>;
 
-    template <typename Info>
-    void addLibrariesForCommand(utbot::BaseCommand *command,
-                                const std::shared_ptr<Info> &info,
+    void addLibrariesForCommand(utbot::BaseCommand &command,
+                                BaseFileInfo &info,
                                 sharedLibrariesMap &sharedLibraryFiles,
                                 bool objectFiles = false);
 };

--- a/server/src/utils/CollectionUtils.h
+++ b/server/src/utils/CollectionUtils.h
@@ -107,6 +107,20 @@ namespace CollectionUtils {
         map = filtered;
         return erased;
     }
+    template <class Pr, typename ...Args>
+    size_t erase_if(tsl::ordered_set<Args...> &set, Pr &&pred) {
+        size_t erased = 0;
+        tsl::ordered_set<Args...> filtered{ set.bucket_count() };
+        for (auto &&it : set) {
+            if (!pred(it)) {
+                filtered.insert(std::move(it));
+            } else {
+                erased++;
+            }
+        }
+        set = filtered;
+        return erased;
+    }
 
     template <typename V, class Pr>
     size_t erase_if(std::list<V> &list, Pr &&pred) {
@@ -221,6 +235,11 @@ namespace CollectionUtils {
     }
     template <typename T, typename Hash, class From>
     void extend(std::unordered_set<T, Hash> &to, From &&from) {
+        to.reserve(to.size() + from.size());
+        to.insert(std::begin(from), std::end(from));
+    }
+    template <typename T, typename Hash, class From>
+    void extend(tsl::ordered_set<T, Hash> &to, From &&from) {
         to.reserve(to.size() + from.size());
         to.insert(std::begin(from), std::end(from));
     }

--- a/server/test/framework/Server_Tests.cpp
+++ b/server/test/framework/Server_Tests.cpp
@@ -1575,4 +1575,17 @@ namespace {
 
         testUtils::checkMinNumberOfTests(testGen.tests, 1);
     }
+
+    TEST_P(Parameterized_Server_Test, Installed_Dependency_Test) {
+        std::string suite = "installed";
+        setSuite(suite);
+        auto request = createProjectRequest(projectName, suitePath, buildDirRelativePath, srcPaths);
+        auto testGen = ProjectTestGen(*request, writer.get(), TESTMODE);
+        testGen.setTargetForSource(testGen.testingMethodsSourcePaths[0]);
+
+        Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
+        ASSERT_TRUE(status.ok()) << status.error_message();
+
+        testUtils::checkMinNumberOfTests(testGen.tests, 2);
+    }
 }

--- a/server/test/framework/main.cpp
+++ b/server/test/framework/main.cpp
@@ -79,6 +79,10 @@ int main(int argc, char **argv) {
 
         testUtils::tryExecGetBuildCommands(testUtils::getRelativeTestSuitePath("stddef"), clang);
 
+        testUtils::tryExecGetBuildCommands(testUtils::getRelativeTestSuitePath("installed"), gcc);
+
+        testUtils::tryExecGetBuildCommands(testUtils::getRelativeTestSuitePath("installed"), clang);
+
     } catch (std::runtime_error const &e) {
         return 1;
     }

--- a/server/test/suites/installed/CMakeLists.txt
+++ b/server/test/suites/installed/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(installed)
+
+find_package(Z3)
+
+message(STATUS "Z3_FOUND: ${Z3_FOUND}")
+message(STATUS "Found Z3 ${Z3_VERSION_STRING}")
+message(STATUS "Z3_DIR: ${Z3_DIR}")
+
+add_executable(installed main.c)
+
+target_include_directories(installed PRIVATE ${Z3_C_INCLUDE_DIRS})
+target_link_libraries(installed PRIVATE ${Z3_LIBRARIES})

--- a/server/test/suites/installed/main.c
+++ b/server/test/suites/installed/main.c
@@ -1,0 +1,12 @@
+#include <z3.h>
+
+void display_version()
+{
+    unsigned major, minor, build, revision;
+    Z3_get_version(&major, &minor, &build, &revision);
+    printf("Z3 %d.%d.%d.%d\n", major, minor, build, revision);
+}
+
+int main() {
+    display_version();
+}


### PR DESCRIPTION
I have put an example of such a project in the test suite `server/test/suites/installed`. If we generate a project model for that, we get one of the possible `link_commands.json` from [there](https://github.com/UnitTestBot/UTBotCpp/issues/90). And since it is hard to distinguish those cases as well as to fix the behavior, I propose the following solution. 

Let's look at dependent file. If there is no target for that, then it's most likely installed library in one of install paths. Based on that, we are able to separate installed files within `BuildDatabase`.

Note: tests are generated successfully, but cannot be run at the moment.