### PR TITLE
Don't print 'return' for void and no-return functions

### DIFF
--- a/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
@@ -289,7 +289,10 @@ void SourceToHeaderMatchCallback::printReturn(const FunctionDecl *decl,
     printer::Printer printer;
     auto args = CollectionUtils::transformTo<std::vector<std::string>>(
         decl->parameters(), [](ParmVarDecl *param) { return param->getNameAsString(); });
-    printer.ss << "return ";
+    bool noReturn = decl->isNoReturn() || decl->getReturnType()->isVoidType();
+    if (!noReturn) {
+        printer.ss << "return ";
+    }
     printer.strFunctionCall(name, args);
 
     *stream << printer.ss.str();

--- a/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
@@ -144,7 +144,7 @@ void SourceToHeaderMatchCallback::handleTypedef(const TypedefDecl *decl) {
     auto canonicalType = decl->getUnderlyingType().getCanonicalType();
     auto name = decl->getName().str();
     auto canonicalName = canonicalType.getAsString();
-    if (name == "wchar_t") {
+    if (name == "wchar_t" && !forStubHeader) {
         // wchar_t is builtin type in C++ but is typedef in C
         return;
     }


### PR DESCRIPTION
Fix #136 