### PR TITLE
Move output option to begin and exclude installed files for archive commands when building IR files

### DIFF
--- a/server/test/framework/Server_Tests.cpp
+++ b/server/test/framework/Server_Tests.cpp
@@ -1587,5 +1587,8 @@ namespace {
         ASSERT_TRUE(status.ok()) << status.error_message();
 
         testUtils::checkMinNumberOfTests(testGen.tests, 2);
+        auto const& cases = testGen.tests.begin().value().methods["display_version"].testCases;
+        ASSERT_EQ(1, cases.size());
+        ASSERT_FALSE(cases[0].isError());
     }
 }

--- a/server/test/suites/installed/CMakeLists.txt
+++ b/server/test/suites/installed/CMakeLists.txt
@@ -8,7 +8,9 @@ message(STATUS "Z3_FOUND: ${Z3_FOUND}")
 message(STATUS "Found Z3 ${Z3_VERSION_STRING}")
 message(STATUS "Z3_DIR: ${Z3_DIR}")
 
-add_executable(installed main.c)
+add_library(lib SHARED lib.c)
+target_include_directories(lib PRIVATE ${Z3_C_INCLUDE_DIRS})
+target_link_libraries(lib PRIVATE ${Z3_LIBRARIES})
 
-target_include_directories(installed PRIVATE ${Z3_C_INCLUDE_DIRS})
-target_link_libraries(installed PRIVATE ${Z3_LIBRARIES})
+add_executable(installed main.c)
+target_link_libraries(installed PRIVATE lib)

--- a/server/test/suites/installed/lib.c
+++ b/server/test/suites/installed/lib.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#include <z3.h>
+
+void display_version() {
+    unsigned major, minor, build, revision;
+    Z3_get_version(&major, &minor, &build, &revision);
+    printf("Z3 %d.%d.%d.%d\n", major, minor, build, revision);
+}

--- a/server/test/suites/installed/lib.h
+++ b/server/test/suites/installed/lib.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#ifndef UNITTESTBOT_LIB_H
+#define UNITTESTBOT_LIB_H
+
+
+void display_version();
+
+
+#endif // UNITTESTBOT_LIB_H

--- a/server/test/suites/installed/main.c
+++ b/server/test/suites/installed/main.c
@@ -1,11 +1,8 @@
-#include <z3.h>
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
 
-void display_version()
-{
-    unsigned major, minor, build, revision;
-    Z3_get_version(&major, &minor, &build, &revision);
-    printf("Z3 %d.%d.%d.%d\n", major, minor, build, revision);
-}
+#include "lib.h"
 
 int main() {
     display_version();


### PR DESCRIPTION
The problem happens for such original link command where installed file is placed before output option
```json
"arguments": [
            "/utbot_distr/install/bin/clang",
            "-fPIC",
            "-O3",
            "-DNDEBUG",
            "-fuse-ld=gold",
            "-shared",
            "/usr/lib/x86_64-linux-gnu/libz.so",
            "../zstd/libzstd.so",
            "-o",
            "libSZ.so",
            "CMakeFiles/SZ.dir/src/ArithmeticCoding.c.o",
            ...
]
```

Fixes #148 