### PR TITLE
Create command line option '--klee-process-number' whose value is passed to '--process-number' of KLEE (default=5)

### DIFF
--- a/server/src/KleeRunner.cpp
+++ b/server/src/KleeRunner.cpp
@@ -283,7 +283,7 @@ void KleeRunner::processBatchWithInteractive(const std::vector<tests::TestMethod
                                           "--check-overshift=false",
                                           "--skip-not-lazy-and-symbolic-pointers",
                                           "--interactive",
-                                          "--process-number=5",
+                                          KleeUtils::processNumberOption(),
                                           entrypointsArg,
                                           outputDir };
     if (settingsContext.timeoutPerFunction.has_value()) {

--- a/server/src/commands/Commands.cpp
+++ b/server/src/commands/Commands.cpp
@@ -6,6 +6,9 @@
 
 #include "utils/StringUtils.h"
 
+uint32_t Commands::threadsPerUser = 0;
+uint32_t Commands::kleeProcessNumber = 0;
+
 Commands::MainCommands::MainCommands(CLI::App &app) {
 
     app.set_help_all_flag("--help-all", "Expand all help");
@@ -44,6 +47,8 @@ Commands::ServerCommandOptions::ServerCommandOptions(CLI::App *command) {
         ->type_name(" ENUM:value in {" +
                     StringUtils::joinWith(CollectionUtils::getKeys(verbosityMap), "|") + "}")
         ->transform(CLI::CheckedTransformer(verbosityMap, CLI::ignore_case));
+    command->add_option("--klee-process-number", kleeProcessNumber,
+                        "Number of threads for KLEE in interactive mode");
 }
 
 fs::path Commands::ServerCommandOptions::getLogPath() {
@@ -64,6 +69,10 @@ loguru::NamedVerbosity Commands::ServerCommandOptions::getVerbosity() {
 
 unsigned int Commands::ServerCommandOptions::getThreadsPerUser() {
     return threadsPerUser;
+}
+
+unsigned int Commands::ServerCommandOptions::getKleeProcessNumber() {
+    return kleeProcessNumber;
 }
 
 const std::map<std::string, loguru::NamedVerbosity> Commands::ServerCommandOptions::verbosityMap = {

--- a/server/src/commands/Commands.h
+++ b/server/src/commands/Commands.h
@@ -17,7 +17,8 @@
 
 
 namespace Commands {
-    static unsigned int threadsPerUser = 0;
+    extern uint32_t threadsPerUser;
+    extern uint32_t kleeProcessNumber;
 
     struct MainCommands {
         explicit MainCommands(CLI::App &app);
@@ -51,6 +52,7 @@ namespace Commands {
 
         unsigned int getThreadsPerUser();
 
+        unsigned int getKleeProcessNumber();
     private:
         unsigned int port = 0;
         fs::path logPath, tmpPath;

--- a/server/src/utils/CLIUtils.h
+++ b/server/src/utils/CLIUtils.h
@@ -15,8 +15,6 @@
 #include <string>
 
 namespace CLIUtils {
-    extern unsigned int threadsPerUser;
-
     void setOptPath(const std::string &optPath, fs::path &var);
 
     void setupLogger(const std::string &logPath,

--- a/server/src/utils/KleeUtils.cpp
+++ b/server/src/utils/KleeUtils.cpp
@@ -7,6 +7,7 @@
 #include "LogUtils.h"
 #include "Paths.h"
 #include "TimeExecStatistics.h"
+#include "commands/Commands.h"
 
 #include "loguru.h"
 
@@ -99,5 +100,11 @@ namespace KleeUtils {
 
     string postSymbolicVariable(const string &variableName) {
         return variableName + "_post";
+    }
+    std::string processNumberOption() {
+        if (Commands::kleeProcessNumber != 0) {
+            return "--process-number=" + std::to_string(Commands::kleeProcessNumber);
+        }
+        return "--process-number=5";
     }
 }

--- a/server/src/utils/KleeUtils.h
+++ b/server/src/utils/KleeUtils.h
@@ -25,6 +25,8 @@ namespace KleeUtils {
                               bool needToMangle = false);
 
     std::string postSymbolicVariable(const string& variableName);
+
+    std::string processNumberOption();
 }
 
 #endif // CORE_KLEEUTIL_H


### PR DESCRIPTION
Closes #161 

## Test plan

1. Run `utbot server --verbosity debug --klee-process-number 8`
2. Request generation for file
3. Check logs
```
Klee command :: klee ... --process-number=8 ... /home/utbot/tmp/utbot-ZZR7/coreutils/build/lib/libcoreutils.bc --sym-stdin 64
```