### PR TITLE
Introduce 'wchar_t' type using '#define' within the scope of test header

### DIFF
--- a/server/src/NameDecorator.cpp
+++ b/server/src/NameDecorator.cpp
@@ -17,6 +17,15 @@ std::string NameDecorator::decorate(std::string_view name) {
     return result;
 }
 
+std::string NameDecorator::defineWcharT(std::string_view canonicalName) {
+    return StringUtils::stringFormat("#define wchar_t %.*s", canonicalName.length(),
+                                     canonicalName.data());
+}
+
+const std::string NameDecorator::UNDEF_WCHAR_T = "#ifdef wchar_t\n"
+                                                 "#undef wchar_t\n"
+                                                 "#endif\n";
+
 // https://en.cppreference.com/w/c/keyword
 const std::unordered_set<std::string> NameDecorator::C_KEYWORDS = {
     "auto",    "break",  "case",     "char",   "const",    "continue", "default",

--- a/server/src/NameDecorator.h
+++ b/server/src/NameDecorator.h
@@ -14,6 +14,10 @@ class NameDecorator {
 public:
     static std::string decorate(std::string_view name);
 
+    static std::string defineWcharT(std::string_view canonicalName);
+
+    static const std::string UNDEF_WCHAR_T;
+
     static const std::unordered_set<std::string> C_KEYWORDS;
 
     static const std::unordered_set<std::string> CPP_KEYWORDS;

--- a/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
@@ -145,7 +145,10 @@ void SourceToHeaderMatchCallback::handleTypedef(const TypedefDecl *decl) {
     auto name = decl->getName().str();
     auto canonicalName = canonicalType.getAsString();
     if (name == "wchar_t" && !forStubHeader) {
-        // wchar_t is builtin type in C++ but is typedef in C
+        // wchar_t is builtin type in C++ but is typedef in C, so let's define it
+        if (externalStream != nullptr) {
+            *externalStream << NameDecorator::defineWcharT(canonicalName) << "\n";
+        }
         return;
     }
     if (name == canonicalName) {

--- a/server/src/clang-utils/SourceToHeaderRewriter.cpp
+++ b/server/src/clang-utils/SourceToHeaderRewriter.cpp
@@ -90,13 +90,14 @@ std::string SourceToHeaderRewriter::generateTestHeader(const fs::path &sourceFil
         "%s\n"
         "%s\n"
         "%s\n"
+        "%s\n"
         "}\n"
         "%s\n",
         Copyright::GENERATED_C_CPP_FILE_HEADER, PrinterUtils::TEST_NAMESPACE,
         NameDecorator::DEFINES_CODE, PrinterUtils::DEFINES_FOR_C_KEYWORDS,
         PrinterUtils::KNOWN_IMPLICIT_RECORD_DECLS_CODE,
         sourceDeclarations.externalDeclarations, sourceDeclarations.internalDeclarations,
-        NameDecorator::UNDEFS_CODE);
+        NameDecorator::UNDEF_WCHAR_T, NameDecorator::UNDEFS_CODE);
 }
 
 std::string SourceToHeaderRewriter::generateStubHeader(const fs::path &sourceFilePath) {

--- a/server/test/framework/Server_Tests.cpp
+++ b/server/test/framework/Server_Tests.cpp
@@ -1573,7 +1573,7 @@ namespace {
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
-        testUtils::checkMinNumberOfTests(testGen.tests, 1);
+        testUtils::checkMinNumberOfTests(testGen.tests, 2);
     }
 
     TEST_P(Parameterized_Server_Test, Installed_Dependency_Test) {

--- a/server/test/suites/stddef/CMakeLists.txt
+++ b/server/test/suites/stddef/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-add_executable(stddef stddef.c)
+add_library(stddef stddef.c)

--- a/server/test/suites/stddef/stddef.c
+++ b/server/test/suites/stddef/stddef.c
@@ -1,6 +1,5 @@
 #include <stddef.h>
 
-int main() {
-    const wchar_t wc[3] = L"中国";
-    return 0;
+_Bool iswprint(wchar_t* wc) {
+    return *wc >= ' ' && *wc <= '~';
 }


### PR DESCRIPTION
Fix #167 

- Canonical types are used (`int` for C-like `wchar_t`) in the test source files, so we don't care about them there
- Non-canonical types are redefined (C-like `wchar_t` for `int`) within the scope of the test header file

Example of work for `utbot_tests/gl/lib/mbsalign_test.h`:

![image](https://user-images.githubusercontent.com/31903947/163948731-860d79d9-7e19-4327-966b-73b30b22c35a.png)