### PR TITLE
Change '-I' to '-iquote' option for the search of header files in cases where we add current directory to the list to be searched

### DIFF
--- a/server/src/KleeGenerator.cpp
+++ b/server/src/KleeGenerator.cpp
@@ -142,7 +142,7 @@ KleeGenerator::getCompileCommandForKlee(const fs::path &hintPath,
     command.addFlagsToBegin(flags);
     command.addFlagsToBegin(extraFlags);
     command.addFlagToBegin(
-        StringUtils::stringFormat("-I%s", compilationUnitInfo->getSourcePath().parent_path()));
+        StringUtils::stringFormat("-iquote%s", compilationUnitInfo->getSourcePath().parent_path()));
     LOG_S(MAX) << "New compile command with klee required flags: " << command.toString();
     return command;
 }

--- a/server/src/printers/NativeMakefilePrinter.cpp
+++ b/server/src/printers/NativeMakefilePrinter.cpp
@@ -203,7 +203,7 @@ namespace printer {
         compileCommand.addFlagToBegin(
             stringFormat("-MT $@ -MMD -MP -MF %s", temporaryDependencyFile));
         compileCommand.addFlagToBegin(
-            stringFormat("-I%s", compilationUnitInfo.getSourcePath().parent_path()));
+            stringFormat("-iquote%s", compilationUnitInfo.getSourcePath().parent_path()));
 
         string makingDependencyDirectory =
             stringFormat("mkdir -p %s", dependencyFile.parent_path());


### PR DESCRIPTION
Initially, I encountered the issues when was not able to compile the wrapper without the following warning.

```
/home/utbot/projects/coreutils/build/utbot/wrapper/gnulib/lib/malloc/dynarray_resize_wrapper.c:9:8: warning: implicit declaration of function 'gl_dynarray_resize' is invalid in C99 [-Wimplicit-function-declaration]
return gl_dynarray_resize(list, size, scratch, element_size);
       ^
1 warning generated.
```

Then, I took a closer look at compile command for the wrapper and didn't see anything suspicious. So I compared include paths of given command for the wrapper (on the left) and initial command from `cc.json` (on the right).

![image](https://user-images.githubusercontent.com/31903947/163950054-1a7a6a2f-adaa-42a0-aaaa-5cb0eae30ac7.png)

As it turned out, `#include <dynarray.h>` is looked up [differently](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) due to the extra `-I` option. We can't drop it because the wrapper file does have a different folder. Alternatively, `-iquote` may be used in this case. 
