### PR TITLE
Compile tests 2 way by shared lib or object. issue-143

### DIFF
--- a/server/src/Paths.cpp
+++ b/server/src/Paths.cpp
@@ -309,21 +309,26 @@ namespace Paths {
         return replaceExtension(sourcePathToStubName(source), ".h");
     }
 
-
     fs::path sourcePathToStubPath(const utbot::ProjectContext &projectContext,
                                   const fs::path &source) {
         return normalizedTrimmed((projectContext.testDirPath / "stubs" / getRelativeDirPath(projectContext, source) /
                sourcePathToStubName(source)));
     }
+
     fs::path testPathToSourcePath(const utbot::ProjectContext &projectContext,
                                   const fs::path &testFilePath) {
         fs::path relative = fs::relative(testFilePath.parent_path(), projectContext.testDirPath);
         fs::path filename = testPathToSourceName(testFilePath);
         return projectContext.projectPath / relative / filename;
     }
+
     fs::path getMakefilePathFromSourceFilePath(const utbot::ProjectContext &projectContext,
-                                               const fs::path &sourceFilePath) {
+                                               const fs::path &sourceFilePath,
+                                               const string& suffix) {
         fs::path makefileDir = getMakefileDir(projectContext, sourceFilePath);
+        if (!suffix.empty()) {
+            addSuffix(makefileDir, suffix);
+        }
         string makefileName = replaceExtension(sourceFilePath, MAKEFILE_EXTENSION).filename();
         return makefileDir / makefileName;
     }

--- a/server/src/Paths.h
+++ b/server/src/Paths.h
@@ -347,7 +347,8 @@ namespace Paths {
 
     fs::path getRelativeDirPath(const utbot::ProjectContext &projectContext, const fs::path &source);
 
-    fs::path getMakefilePathFromSourceFilePath(const utbot::ProjectContext &projectContext, const fs::path &sourceFilePath);
+    fs::path getMakefilePathFromSourceFilePath(const utbot::ProjectContext &projectContext, const fs::path &sourceFilePath,
+                                               const string& suffix = "");
 
     fs::path getStubsMakefilePath(const utbot::ProjectContext &projectContext, const fs::path &sourceFilePath);
 

--- a/server/src/building/Linker.h
+++ b/server/src/building/Linker.h
@@ -11,6 +11,7 @@
 #include "RunCommand.h"
 #include "printers/DefaultMakefilePrinter.h"
 #include "printers/NativeMakefilePrinter.h"
+#include "printers/TestMakefilesPrinter.h"
 #include "testgens/BaseTestGen.h"
 #include "utils/CollectionUtils.h"
 #include "utils/MakefileUtils.h"
@@ -60,7 +61,7 @@ private:
     CollectionUtils::MapFileTo<fs::path> bitcodeFileName;
     CollectionUtils::FileSet brokenLinkFiles;
 
-    CollectionUtils::MapFileTo<std::string> linkMakefiles;
+    std::vector<printer::TestMakefilesContent> linkMakefiles;
 
     IRParser irParser;
 

--- a/server/src/coverage/LlvmCoverageTool.cpp
+++ b/server/src/coverage/LlvmCoverageTool.cpp
@@ -81,6 +81,10 @@ LlvmCoverageTool::getCoverageCommands(const vector<UnitTest> &testsToLaunch) {
             auto makefileCommand = MakefileUtils::makefileCommand(projectContext, makefile, "bin");
             auto res = makefileCommand.run();
             if (res.status == 0) {
+                if (res.output.empty()) {
+                    throw CoverageGenerationException(
+                            "Coverage result empty. See logs for more information.");
+                }
                 return StringUtils::split(res.output, '\n').back();
             }
             throw CoverageGenerationException(

--- a/server/src/printers/DefaultMakefilePrinter.h
+++ b/server/src/printers/DefaultMakefilePrinter.h
@@ -23,18 +23,18 @@ public:
 
     void declareAction(std::string const &name);
 
-    template <class ContainerD = std::initializer_list<std::string>,
-              class ContainerA = std::initializer_list<std::string>>
+    template<class ContainerD = std::initializer_list<std::string>,
+            class ContainerA = std::initializer_list<std::string>>
     void declareTarget(std::string const &name,
                        ContainerD &&dependencies,
                        ContainerA &&actions) {
         ss << StringUtils::stringFormat(
-            "%s : %s\n\t%s\n", name,
-            StringUtils::joinWith(std::forward<ContainerD>(dependencies), " "),
-            StringUtils::joinWith(std::forward<ContainerA>(actions), "\n\t"));
+                "%s : %s\n\t%s\n", name,
+                StringUtils::joinWith(std::forward<ContainerD>(dependencies), " "),
+                StringUtils::joinWith(std::forward<ContainerA>(actions), "\n\t"));
     }
 
-    void declareInclude(const std::string& otherMakefileName);
+    void declareInclude(const std::string &otherMakefileName);
 
 protected:
     void writeCopyrightHeader() final;

--- a/server/src/printers/NativeMakefilePrinter.cpp
+++ b/server/src/printers/NativeMakefilePrinter.cpp
@@ -34,7 +34,6 @@ namespace printer {
     static const std::string RELOCATE_FLAG = "-r";
     static const std::string OPTIMIZATION_FLAG = "-O0";
 
-    static const std::string FORCE = ".FORCE";
 
 
     static void eraseIfWlOnly(string &argument) {
@@ -375,7 +374,7 @@ namespace printer {
                                               SanitizerUtils::ASAN_OPTIONS_VALUE);
 
         declareTarget("build", { testExecutablePath }, {});
-        declareTarget("run", { FORCE, "build" },
+        declareTarget("run", { "build" },
                       { testRunCommand.toStringWithChangingDirectory() });
 
         close();
@@ -384,7 +383,8 @@ namespace printer {
     BuildResult
     NativeMakefilePrinter::addLinkTargetRecursively(const fs::path &unitFile,
                                                     const std::string &suffixForParentOfStubs,
-                                                    bool hasParent) {
+                                                    bool hasParent,
+                                                    bool transformExeToLib) {
         if (CollectionUtils::contains(buildResults, unitFile)) {
             return buildResults.at(unitFile);
         }
@@ -399,7 +399,7 @@ namespace printer {
         auto unitBuildResults = CollectionUtils::transformTo<std::vector<BuildResult>>(
             linkUnitInfo->files, [&](fs::path const &dependency) {
                 BuildResult buildResult =
-                    addLinkTargetRecursively(dependency, suffixForParentOfStubs, true);
+                    addLinkTargetRecursively(dependency, suffixForParentOfStubs, true, transformExeToLib);
                 unitType |= buildResult.type;
                 fileMapping[dependency] = buildResult.output;
                 return buildResult;
@@ -412,11 +412,11 @@ namespace printer {
 
         fs::path recompiledFile =
             Paths::getRecompiledFile(projectContext, linkUnitInfo->getOutput());
-        if (isExecutable) {
+        if (isExecutable && !transformExeToLib) {
             recompiledFile = Paths::isObjectFile(recompiledFile) ?
                              recompiledFile : Paths::addExtension(recompiledFile, ".o");
-        } else if (Paths::isSharedLibraryFile(unitFile)) {
-            recompiledFile = getSharedLibrary(linkUnitInfo->getOutput());
+        } else if (Paths::isSharedLibraryFile(unitFile) || isExecutable) {
+            recompiledFile = getSharedLibrary(recompiledFile);
         }
         recompiledFile = LinkerUtils::applySuffix(recompiledFile, unitType, suffixForParentOfStubs);
 
@@ -434,7 +434,7 @@ namespace printer {
                     }
                 }
                 if (!linkCommand.isArchiveCommand()) {
-                    if (isExecutable) {
+                    if (isExecutable && !transformExeToLib) {
                         linkCommand.setLinker(Paths::getLd());
                     } else {
                         linkCommand.setLinker(CompilationUtils::getBundledCompilerPath(
@@ -457,7 +457,7 @@ namespace printer {
                         }
                     }
                     linkCommand.addFlagsToBegin(libraryDirectoriesFlags);
-                    if (!isExecutable) {
+                    if (!isExecutable || transformExeToLib) {
                         linkCommand.addFlagsToBegin({"-Wl,--allow-multiple-definition",
                                                      coverageLinkFlags, sanitizerLinkFlags, "-Wl,--whole-archive"});
                         if (linkCommand.isSharedLibraryCommand()) {
@@ -469,13 +469,15 @@ namespace printer {
                     }
                     linkCommand.addFlagToBegin("$(LDFLAGS)");
                     if (isExecutable) {
-                        linkCommand.addFlagToBegin(RELOCATE_FLAG);
+                        linkCommand.addFlagToBegin(transformExeToLib ? SHARED_FLAG : RELOCATE_FLAG);
                     }
                 }
-                return isExecutable ? stringFormat("%s && objcopy --redefine-sym main=old_main %s",
-                                                   linkCommand.toStringWithChangingDirectory(),
-                                                   linkCommand.getOutput().string()) :
-                                      linkCommand.toStringWithChangingDirectory();
+                if (isExecutable && !transformExeToLib) {
+                    return stringFormat("%s && objcopy --redefine-sym main=main__ %s",
+                                        linkCommand.toStringWithChangingDirectory(),
+                                        linkCommand.getOutput().string());
+                }
+                return linkCommand.toStringWithChangingDirectory();
             });
         std::string removeAction = stringFormat("rm -f %s", recompiledFile);
         std::vector<std::string> actions{ removeAction };
@@ -542,9 +544,9 @@ namespace printer {
         ss << "\n";
     }
 
-    BuildResult
-    NativeMakefilePrinter::addLinkTargetRecursively(const fs::path &unitFile,
-                                                    const string &suffixForParentOfStubs) {
-        return addLinkTargetRecursively(unitFile, suffixForParentOfStubs, false);
+    void NativeMakefilePrinter::addLinkTargetRecursively(const fs::path &unitFile,
+                                                         const string &suffixForParentOfStubs,
+                                                         bool exeToLib) {
+        addLinkTargetRecursively(unitFile, suffixForParentOfStubs, false, exeToLib);
     }
 }

--- a/server/src/printers/NativeMakefilePrinter.h
+++ b/server/src/printers/NativeMakefilePrinter.h
@@ -13,6 +13,8 @@
 #include <vector>
 
 namespace printer {
+    static const std::string FORCE = ".FORCE";
+
     class NativeMakefilePrinter : public DefaultMakefilePrinter {
     private:
         const utbot::ProjectContext projectContext;
@@ -58,15 +60,18 @@ namespace printer {
         void addCompileTarget(const fs::path &sourcePath,
                               const fs::path &output,
                               const BuildDatabase::ObjectFileInfo &compilationUnitInfo);
+
         fs::path getTestExecutablePath(const fs::path &sourcePath) const;
 
         BuildResult addLinkTargetRecursively(const fs::path &unitFile,
                                              const std::string &suffixForParentOfStubs,
-                                             bool hasParent);
+                                             bool hasParent,
+                                             bool transformExeToLib);
+
     public:
         NativeMakefilePrinter(utbot::ProjectContext projectContext,
                               shared_ptr<BuildDatabase> buildDatabase,
-                              fs::path const& rootPath,
+                              fs::path const &rootPath,
                               fs::path primaryCompiler,
                               CollectionUtils::FileSet const *stubSources);
 
@@ -80,8 +85,9 @@ namespace printer {
 
         void close();
 
-        BuildResult addLinkTargetRecursively(const fs::path &unitFile,
-                                             const string &suffixForParentOfStubs);
+        void addLinkTargetRecursively(const fs::path &unitFile,
+                                      const string &suffixForParentOfStubs,
+                                      bool exeToLib = true);
 
         void addStubs(const CollectionUtils::FileSet &stubsSet);
     };

--- a/server/src/printers/TestMakefilesPrinter.cpp
+++ b/server/src/printers/TestMakefilesPrinter.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#include "TestMakefilesPrinter.h"
+#include "utils/FileSystemUtils.h"
+
+#include <utility>
+#include <utils/MakefileUtils.h>
+
+namespace printer {
+    fs::path getMakefilePathForShared(fs::path path) {
+        return Paths::addSuffix(Paths::addPrefix(path, "__"), "_shared");
+    }
+
+    fs::path getMakefilePathForObject(fs::path path) {
+        return Paths::addSuffix(Paths::addPrefix(path, "__"), "_obj");
+    }
+
+    void TestMakefilesContent::write() const {
+        FileSystemUtils::writeToFile(path, generalMakefileContent);
+        fs::path sharedMakefilePath = getMakefilePathForShared(path);
+        FileSystemUtils::writeToFile(sharedMakefilePath, sharedMakefileContent);
+        fs::path objMakefilePath = getMakefilePathForObject(path);
+        FileSystemUtils::writeToFile(objMakefilePath, objMakefileContent);
+    }
+
+    TestMakefilesContent::TestMakefilesContent(fs::path path, std::string generalMakefileStr,
+                                               std::string sharedMakefileStr,
+                                               std::string objMakefileStr) :
+            path(std::move(path)), generalMakefileContent(std::move(generalMakefileStr)),
+            sharedMakefileContent(std::move(sharedMakefileStr)), objMakefileContent(std::move(objMakefileStr)) {
+    }
+
+    TestMakefilesPrinter::TestMakefilesPrinter(const BaseTestGen &testGen,
+                                               CollectionUtils::FileSet const *stubSources) :
+            projectContext(testGen.projectContext),
+            sharedMakefilePrinter(testGen, stubSources),
+            objMakefilePrinter(testGen, stubSources) {
+    }
+
+    void
+    TestMakefilesPrinter::addLinkTargetRecursively(const fs::path &unitFile, const string &suffixForParentOfStubs) {
+        sharedMakefilePrinter.addLinkTargetRecursively(unitFile, suffixForParentOfStubs, true);
+        objMakefilePrinter.addLinkTargetRecursively(unitFile, suffixForParentOfStubs, false);
+    }
+
+    void TestMakefilesPrinter::close() {
+        sharedMakefilePrinter.close();
+        objMakefilePrinter.close();
+    }
+
+    void TestMakefilesPrinter::init() {
+        sharedMakefilePrinter.init();
+        objMakefilePrinter.init();
+    }
+
+    void TestMakefilesPrinter::addStubs(const CollectionUtils::FileSet &stubsSet) {
+        sharedMakefilePrinter.addStubs(stubsSet);
+        objMakefilePrinter.addStubs(stubsSet);
+    }
+
+    TestMakefilesContent TestMakefilesPrinter::GetMakefiles(const fs::path &path) const {
+        printer::DefaultMakefilePrinter generalMakefilePrinter;
+        fs::path generalMakefilePath = Paths::getMakefilePathFromSourceFilePath(projectContext, path);
+        fs::path sharedMakefilePath = getMakefilePathForShared(generalMakefilePath);
+        fs::path objMakefilePath = getMakefilePathForObject(generalMakefilePath);
+
+        generalMakefilePrinter.declareTarget(FORCE, {}, {});
+
+        generalMakefilePrinter.declareTarget("bin", {FORCE}, {
+                StringUtils::joinWith(
+                        MakefileUtils::getMakeCommand(sharedMakefilePath.string(), "bin", true),
+                        " ")
+        });
+        generalMakefilePrinter.declareTarget("run", {FORCE}, {
+                StringUtils::stringFormat("%s && { %s; exit $$?; } || { %s && { %s; exit $$?; } }",
+                                          StringUtils::joinWith(MakefileUtils::getMakeCommand(
+                                                  sharedMakefilePath.string(), "build", true), " "),
+                                          StringUtils::joinWith(MakefileUtils::getMakeCommand(
+                                                  sharedMakefilePath.string(), "run", true), " "),
+                                          StringUtils::joinWith(MakefileUtils::getMakeCommand(
+                                                  objMakefilePath.string(), "build", true), " "),
+                                          StringUtils::joinWith(MakefileUtils::getMakeCommand(
+                                                  objMakefilePath.string(), "run", true), " "))
+        });
+        generalMakefilePrinter.declareTarget("clean", {FORCE}, {
+                StringUtils::joinWith(
+                        MakefileUtils::getMakeCommand(sharedMakefilePath.string(), "clean", true), " "),
+                StringUtils::joinWith(
+                        MakefileUtils::getMakeCommand(objMakefilePath.string(), "clean", true), " ")
+        });
+
+        return {generalMakefilePath,
+                generalMakefilePrinter.ss.str(),
+                NativeMakefilePrinter(sharedMakefilePrinter, path).ss.str(),
+                NativeMakefilePrinter(objMakefilePrinter, path).ss.str()};
+    }
+}

--- a/server/src/printers/TestMakefilesPrinter.h
+++ b/server/src/printers/TestMakefilesPrinter.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.
+ */
+
+#ifndef UNITTESTBOT_TESTMAKEFILESPRINTER_H
+#define UNITTESTBOT_TESTMAKEFILESPRINTER_H
+
+#include "NativeMakefilePrinter.h"
+
+namespace printer {
+    class TestMakefilesContent {
+    private:
+        fs::path path;
+        std::string generalMakefileContent;
+        std::string sharedMakefileContent;
+        std::string objMakefileContent;
+
+    public:
+        TestMakefilesContent(fs::path path, std::string generalMakefileStr,
+                             std::string sharedMakefileStr, std::string objMakefileStr);
+
+        void write() const;
+    };
+
+    class TestMakefilesPrinter {
+    private:
+        utbot::ProjectContext projectContext;
+        printer::NativeMakefilePrinter sharedMakefilePrinter;
+        printer::NativeMakefilePrinter objMakefilePrinter;
+
+    public:
+        TestMakefilesPrinter(const BaseTestGen &testGen,
+                             CollectionUtils::FileSet const *stubSources);
+
+        void init();
+
+        void close();
+
+        void addLinkTargetRecursively(const fs::path &unitFile, const string &suffixForParentOfStubs);
+
+        void addStubs(const CollectionUtils::FileSet &stubsSet);
+
+        [[nodiscard]] TestMakefilesContent GetMakefiles(const fs::path &path) const;
+    };
+}
+
+#endif //UNITTESTBOT_TESTMAKEFILESPRINTER_H

--- a/server/src/utils/MakefileUtils.h
+++ b/server/src/utils/MakefileUtils.h
@@ -45,6 +45,8 @@ namespace MakefileUtils {
                                     const std::string &gtestFlags = "",
                                     const std::vector <std::string> &env = {});
 
+    std::vector<std::string> getMakeCommand(std::string makefile, std::string target, bool nested);
+
     std::string threadFlag();
 }
 


### PR DESCRIPTION
This pr fix [issue-143](https://github.com/UnitTestBot/UTBotCpp/issues/143) create 3 makefile for 1 file:
  1) same as before [commit](https://github.com/UnitTestBot/UTBotCpp/commit/e1a96d9cae936a8735998871f3a38f6ad4178e3f#diff-155fa58ace015058333d0b5407eac8d3c65d77a1d9c2132417be735f259064a1R406) with name `__filename_shared.mk`
  2) like after this  [commit](https://github.com/UnitTestBot/UTBotCpp/commit/e1a96d9cae936a8735998871f3a38f6ad4178e3f#diff-155fa58ace015058333d0b5407eac8d3c65d77a1d9c2132417be735f259064a1R406)  with name `__filename_obj.mk`.
  3) same name as before that has three targets
    * `bin` that just call bin of `__filename_shared.mk`
    * `run` try call `run` target of `__filename_shared.mk` and if fail call `run` target of `__filename_obj.mk`
    * `clean` just run `clean` target `__filename_shared.mk` and `__filename_obj.mk`.