### PR TITLE
Don't print alignment for expected values

### DIFF
--- a/server/src/printers/NativeMakefilePrinter.cpp
+++ b/server/src/printers/NativeMakefilePrinter.cpp
@@ -44,7 +44,6 @@ namespace printer {
     }
 
     static void removeLinkerFlag(string &argument, string const &flag) {
-        eraseIfWlaAsNeeded(argument);
         auto options = StringUtils::split(argument, ',');
         size_t erased = CollectionUtils::erase_if(options, [&flag](string const &option) {
             return StringUtils::startsWith(option, flag);

--- a/server/src/printers/NativeMakefilePrinter.cpp
+++ b/server/src/printers/NativeMakefilePrinter.cpp
@@ -44,6 +44,7 @@ namespace printer {
     }
 
     static void removeLinkerFlag(string &argument, string const &flag) {
+        eraseIfWlaAsNeeded(argument);
         auto options = StringUtils::split(argument, ',');
         size_t erased = CollectionUtils::erase_if(options, [&flag](string const &option) {
             return StringUtils::startsWith(option, flag);

--- a/server/src/visitors/ParametrizedAssertsVisitor.cpp
+++ b/server/src/visitors/ParametrizedAssertsVisitor.cpp
@@ -50,8 +50,9 @@ namespace visitor {
                     printer->strDeclareVar(
                             printer::Printer::getConstQualifier(type) + type.usedType(), PrinterUtils::ACTUAL,
                             functionCall, std::nullopt, true, additionalPointersCount);
-                    printer->strDeclareArrayVar(type, PrinterUtils::fillVarName(access, PrinterUtils::EXPECTED), usage,
-                                                view->getEntryValue(), true);
+                    printer->strDeclareArrayVar(
+                        type, PrinterUtils::fillVarName(access, PrinterUtils::EXPECTED), usage,
+                        view->getEntryValue(), std::nullopt, true);
                 }
             } else {
                 return AbstractValueViewVisitor::visitAny(type.baseTypeObj(), name, view, access, depth);


### PR DESCRIPTION
## Before

```cpp
TEST(regression, make_node_op_equals_test_1)
{
    struct mode_change * actual = make_node_op_equals(0U, 0U);
    attribute ((aligned(1))) struct mode_change expected[1] = {{'=', '\x01', 4095U, 0U, 0U}};
    for (int it_2_0 = 0; it_2_0 < 1; it_2_0 ++) {
        EXPECT_EQ(expected[it_2_0], actual[it_2_0]);
    }
}
```

## After

```cpp
TEST(regression, make_node_op_equals_test_1)
{
    struct mode_change * actual = make_node_op_equals(0U, 0U);
    struct mode_change expected[1] = {{'=', '\x01', 4095U, 0U, 0U}};
    for (int it_2_0 = 0; it_2_0 < 1; it_2_0 ++) {
        EXPECT_EQ(expected[it_2_0], actual[it_2_0]);
    }
}
```