### PR TITLE
Don't print asserts for error suite

### DIFF
--- a/server/src/printers/TestsPrinter.cpp
+++ b/server/src/printers/TestsPrinter.cpp
@@ -519,9 +519,11 @@ void TestsPrinter::parametrizedAsserts(const Tests::MethodDescription &methodDes
                                        const std::optional<LineInfo::PredicateInfo>& predicateInfo) {
     auto visitor = visitor::ParametrizedAssertsVisitor(typesHandler, this, predicateInfo, testCase.isError());
     visitor.visit(methodDescription, testCase);
-    globalParamsAsserts(methodDescription, testCase);
-    classAsserts(methodDescription, testCase);
-    changeableParamsAsserts(methodDescription, testCase);
+    if (!testCase.isError()) {
+        globalParamsAsserts(methodDescription, testCase);
+        classAsserts(methodDescription, testCase);
+        changeableParamsAsserts(methodDescription, testCase);
+    }
 }
 
 std::vector<string> TestsPrinter::methodParametersListParametrized(const Tests::MethodDescription &methodDescription,


### PR DESCRIPTION
# Before
```cpp
TEST(error, base64_encode_fast_test_3)
{
    char in[] = "ccccaccccc";
    char out[] = "accccccaca";
    base64_encode_fast(in, 2L, out);
    char expected_out[] = {'\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'};
    for (int it_6_0 = 0; it_6_0 < 10; it_6_0 ++) {
        EXPECT_EQ(expected_out[it_6_0], out[it_6_0]);
    }
}
```

## After
```cpp
TEST(error, base64_encode_fast_test_3)
{
    char in[] = "cccccacccc";
    char out[] = "accbccccca";
    base64_encode_fast(in, 2L, out);
}
```