### PR TITLE
Generate separate output bitcode file when non-root target is chosen

### DIFF
--- a/server/src/building/Linker.h
+++ b/server/src/building/Linker.h
@@ -90,12 +90,11 @@ private:
                                                            const fs::path &stubsMakefile) const;
     Result<utbot::Void> linkWithStubsIfNeeded(const fs::path &linkMakefile, const fs::path &targetBitcode) const;
 
-    void declareRootLibraryTarget(printer::DefaultMakefilePrinter &bitcodeLinkMakefilePrinter,
-                                  const fs::path &output,
-                                  const vector<fs::path> &bitcodeDependencies,
-                                  const fs::path &prefixPath,
-                                  const utbot::RunCommand &removeAction,
-                                  vector<utbot::LinkCommand> archiveActions);
+    fs::path declareRootLibraryTarget(printer::DefaultMakefilePrinter &bitcodeLinkMakefilePrinter,
+                                      const fs::path &output,
+                                      const vector<fs::path> &bitcodeDependencies,
+                                      const fs::path &prefixPath,
+                                      vector<utbot::LinkCommand> archiveActions);
 
     string getLinkArgument(const string &argument,
                            const fs::path &workingDir,


### PR DESCRIPTION
Previously it could be reused between different builds, which is wrong.