### PR TITLE
UTBotCpp-253 Better structure fields initialization in generated tests #253

### DIFF
--- a/server/src/Tests.cpp
+++ b/server/src/Tests.cpp
@@ -294,9 +294,11 @@ std::shared_ptr<StructValueView> KTestObjectParser::structView(const std::vector
                                                                const MapAddressName &fromAddressToName,
                                                                std::vector<InitReference> &initReferences) {
     std::vector<std::shared_ptr<AbstractValueView>> subViews;
+    std::vector<std::string> fields;
     unsigned int curPos = offset;
 
     for (const auto &field: curStruct.fields) {
+        fields.push_back(field.name);
         size_t len = typesHandler.typeSize(field.type);
         unsigned int offsetField = field.offset;
         types::EnumInfo innerEnum;
@@ -373,9 +375,9 @@ std::shared_ptr<StructValueView> KTestObjectParser::structView(const std::vector
     if(curStruct.hasUnnamedFields) {
         auto bytesType = types::Type::createSimpleTypeFromName("utbot_byte");
         const std::shared_ptr<AbstractValueView> rawDataView = arrayView(byteArray, bytesType, curStruct.size, offset, usage);
-        entryValue = PrinterUtils::convertBytesToUnion(curStruct.name, rawDataView->getEntryValue());
+        entryValue = PrinterUtils::convertBytesToUnion(curStruct.name, rawDataView->getEntryValue(nullptr));
     }
-    return std::make_shared<StructValueView>(subViews, entryValue);
+    return std::make_shared<StructValueView>(curStruct.isCLike, fields, subViews, entryValue);
 }
 
 std::string KTestObjectParser::primitiveCharView(const types::Type &type, std::string value) {
@@ -595,7 +597,7 @@ void KTestObjectParser::assignTypeUnnamedVar(Tests::MethodTestCase &testCase,
                 { name, byteValue }, typeAndVarName,
                                                                                  PointerUsage::LAZY, testCase.lazyAddressToName,
                                                                                  testCase.lazyReferences, methodDescription);
-            LOG_S(MAX) << "Fetch lazy object: " << name << " = " << testParamView->getEntryValue();
+            LOG_S(MAX) << "Fetch lazy object: " << name << " = " << testParamView->getEntryValue(nullptr);
             curType.paramValue.lazyParams.emplace_back(paramType, name, std::nullopt);
             curType.paramValue.lazyValues.emplace_back(name, std::nullopt, testParamView);
         }
@@ -712,13 +714,13 @@ void KTestObjectParser::parseTestCases(const UTBotKTestList &cases,
             std::swap(testCase.lazyReferences, testCaseDescription.lazyReferences);
             if (filterByLineFlag) {
                 auto view = testCaseDescription.kleePathFlagSymbolicValue.view;
-                if (!view || view->getEntryValue() != "1") {
+                if (!view || view->getEntryValue(nullptr) != "1") {
                     continue;
                 }
             }
             auto const &predicateInfo = lineInfo ? lineInfo->predicateInfo : std::nullopt;
             if (predicateInfo.has_value() &&
-                !predicateMatch(testCaseDescription.returnValue.view->getEntryValue(), predicateInfo.value())) {
+                !predicateMatch(testCaseDescription.returnValue.view->getEntryValue(nullptr), predicateInfo.value())) {
                 continue;
             }
 
@@ -731,10 +733,10 @@ void KTestObjectParser::parseTestCases(const UTBotKTestList &cases,
 
             if (methodDescription.returnType.isObjectPointer() && !methodDescription.returnType.maybeArray
                 && testCaseDescription.functionReturnNotNullValue.view &&
-                testCaseDescription.functionReturnNotNullValue.view->getEntryValue() == "0") {
+                testCaseDescription.functionReturnNotNullValue.view->getEntryValue(nullptr) == "0") {
                 testCase.returnValue.view = std::make_shared<PrimitiveValueView>(PrinterUtils::C_NULL);
             }
-            traceStream << "\treturn: " << testCase.returnValue.view->getEntryValue();
+            traceStream << "\treturn: " << testCase.returnValue.view->getEntryValue(nullptr);
             LOG_S(MAX) << traceStream.str();
 
             assignTypeUnnamedVar(testCase, methodDescription);
@@ -906,7 +908,7 @@ void KTestObjectParser::processGlobalParamPreValue(Tests::TestCaseDescription &t
 void KTestObjectParser::processSymbolicStdin(Tests::TestCaseDescription &testCaseDescription, std::vector<RawKleeParam> &rawKleeParams) {
     auto &&read = getKleeParamOrThrow(rawKleeParams, "stdin-read");
     std::string &&view = testParameterView(read, {types::Type::longlongType(), "stdin-read"}, types::PointerUsage::PARAMETER,
-                                      testCaseDescription.lazyAddressToName, testCaseDescription.lazyReferences)->getEntryValue();
+                                      testCaseDescription.lazyAddressToName, testCaseDescription.lazyReferences)->getEntryValue(nullptr);
     if (view == "0LL") {
         return;
     } else {
@@ -1132,7 +1134,7 @@ UnionValueView::UnionValueView(
     const std::shared_ptr<AbstractValueView> &rawDataView,
     std::vector<std::shared_ptr<AbstractValueView>, std::allocator<std::shared_ptr<AbstractValueView>>> subViews)
     : AbstractValueView(std::move(subViews)),
-      entryValue(PrinterUtils::convertBytesToUnion(typeName, rawDataView->getEntryValue())) {
+      entryValue(PrinterUtils::convertBytesToUnion(typeName, rawDataView->getEntryValue(nullptr))) {
 }
 
 TestMethod::TestMethod(std::string methodName, fs::path bitcodeFile, fs::path sourceFilename)

--- a/server/src/Tests.h
+++ b/server/src/Tests.h
@@ -24,6 +24,17 @@
 #include <optional>
 
 namespace tests {
+    class StructValueView;
+}
+
+namespace printer {
+    class TestsPrinter;
+    struct MultiLinePrinter {
+        static std::string print(TestsPrinter *printer, const tests::StructValueView *view);
+    };
+}
+
+namespace tests {
 
     const std::string LAZYNAME = "unnamed";
 
@@ -85,7 +96,7 @@ namespace tests {
         /**
          * Returns string representation of the value.
          */
-        [[nodiscard]] virtual std::string getEntryValue() const = 0;
+        [[nodiscard]] virtual std::string getEntryValue(printer::TestsPrinter *printer) const = 0;
 
         virtual bool containsFPSpecialValue() {
             return false;
@@ -98,12 +109,6 @@ namespace tests {
             return this->subViews;
         };
 
-        /**
-         * For StructValueView should return vector of string representations of its field values.
-         */
-        virtual std::vector<std::string> fieldEntryValues() {
-            return {};
-        }
 
     protected:
         explicit AbstractValueView(std::vector<std::shared_ptr<AbstractValueView>> subViews) : subViews(std::move(subViews)) {}
@@ -117,7 +122,7 @@ namespace tests {
     struct JustValueView : AbstractValueView {
         explicit JustValueView(std::string value) : AbstractValueView(), entryValue(std::move(value)) {}
 
-        [[nodiscard]] std::string getEntryValue() const override {
+        [[nodiscard]] std::string getEntryValue(printer::TestsPrinter *printer) const override {
             return entryValue;
         }
 
@@ -135,7 +140,7 @@ namespace tests {
     struct VoidValueView : AbstractValueView {
         explicit VoidValueView() = default;
 
-        [[nodiscard]] std::string getEntryValue() const override {
+        [[nodiscard]] std::string getEntryValue(printer::TestsPrinter *printer) const override {
             return "";
         }
 
@@ -182,10 +187,10 @@ namespace tests {
         explicit ArrayValueView(std::vector<std::shared_ptr<AbstractValueView>> &subViews)
             : AbstractValueView(subViews) {}
 
-        [[nodiscard]] std::string getEntryValue() const override {
+        [[nodiscard]] std::string getEntryValue(printer::TestsPrinter *printer) const override {
             std::vector<std::string> entries;
             for (const auto &subView : subViews) {
-                entries.push_back(subView->getEntryValue());
+                entries.push_back(subView->getEntryValue(printer));
             }
 
             return "{" + StringUtils::joinWith(entries, ", ") + "}";
@@ -203,42 +208,36 @@ namespace tests {
 
     /**
      * Representation of struct value. It's value is stored as a string. Subviews of StructValueView are its fields.
-     * In order to get fields and subfields values (leaves in terms of trees) method fieldEntryValues().
      */
     struct StructValueView : AbstractValueView {
-        explicit StructValueView(std::vector<std::shared_ptr<AbstractValueView>> subViews,
+        explicit StructValueView(bool _isCLike,
+                                 std::vector<std::string> _fields,
+                                 std::vector<std::shared_ptr<AbstractValueView>> subViews,
                                  std::optional<std::string> entryValue)
-            : AbstractValueView(std::move(subViews)), entryValue(std::move(entryValue)) {
+            : AbstractValueView(std::move(subViews)), entryValue(std::move(entryValue)),
+              isCLike(_isCLike),
+              fields(std::move(_fields)){
         }
 
         [[nodiscard]] const std::vector<std::shared_ptr<AbstractValueView>> &getSubViews() const override {
             return this->subViews;
         }
 
-        [[nodiscard]] std::string getEntryValue() const override {
+        [[nodiscard]] std::string getEntryValue(printer::TestsPrinter *printer) const override {
             if (entryValue.has_value()) {
                 return entryValue.value();
             }
 
+            if (printer != nullptr) {
+                return printer::MultiLinePrinter::print(printer, this);
+            }
+
             std::vector<std::string> entries;
             for (const auto &subView : subViews) {
-                entries.push_back(subView->getEntryValue());
+                entries.push_back(subView->getEntryValue(nullptr));
             }
 
             return "{" + StringUtils::joinWith(entries, ", ") + "}";
-        }
-
-        std::vector<std::string> fieldEntryValues() override {
-            std::vector<std::string> result;
-            for (const auto &subView : subViews) {
-                std::vector<std::string> subFieldEntryValues = subView->fieldEntryValues();
-                CollectionUtils::extend(result, subFieldEntryValues);
-                if (subFieldEntryValues.empty()) {
-                    result.push_back(subView->getEntryValue());
-                }
-            }
-
-            return result;
         }
 
         bool containsFPSpecialValue() override {
@@ -249,7 +248,22 @@ namespace tests {
             }
             return false;
         }
+
+        [[nodiscard]] std::string getFieldPrefix(int i) const {
+            std::string prefix = "." + fields[i] + " = ";
+            if (isCLike) {
+                return prefix;
+            }
+            // it is not C Struct-initialization, but C++ List-initialization.
+            // The `designation` isn't allowed.
+            // https://en.cppreference.com/w/c/language/struct_initialization
+            // https://en.cppreference.com/w/cpp/language/list_initialization
+            return  "/*" + prefix + "*/";
+        }
+
     private:
+        bool isCLike;
+        std::vector<std::string> fields;
         std::optional<std::string> entryValue;
     };
 
@@ -263,16 +277,12 @@ namespace tests {
                                 std::vector<std::shared_ptr<AbstractValueView>,
                                 std::allocator<std::shared_ptr<AbstractValueView>>> subViews);
 
-        [[nodiscard]] std::string getEntryValue() const override {
+        [[nodiscard]] std::string getEntryValue(printer::TestsPrinter *printer) const override {
             return entryValue;
         }
 
         bool containsFPSpecialValue() override {
             return false;
-        }
-
-        std::vector<std::string> fieldEntryValues() override {
-            return { getEntryValue() };
         }
 
     private:

--- a/server/src/printers/TestsPrinter.cpp
+++ b/server/src/printers/TestsPrinter.cpp
@@ -185,7 +185,7 @@ void TestsPrinter::printLazyVariables(const std::vector<Tests::MethodParam> &laz
                                       const std::vector<Tests::TestCaseParamValue> &lazyValues) {
     for (size_t i = 0; i < lazyParams.size(); ++i) {
         printLazyVariables(lazyValues[i].lazyParams, lazyValues[i].lazyValues);
-        strDeclareVar(lazyParams[i].type.baseType(), lazyValues[i].name, lazyValues[i].view->getEntryValue(),
+        strDeclareVar(lazyParams[i].type.baseType(), lazyValues[i].name, lazyValues[i].view->getEntryValue(this),
                           std::nullopt, true, lazyParams[i].type.getDimension());
     }
 }
@@ -210,7 +210,7 @@ void TestsPrinter::printStubVariables(const Tests::MethodDescription &methodDesc
         types::Type stubType = testCase.stubParamTypes[i].type;
         std::string bufferSuffix = "_buffer";
         std::string buffer = stub.name + bufferSuffix;
-        strDeclareArrayVar(stubType, buffer, types::PointerUsage::PARAMETER, stub.view->getEntryValue());
+        strDeclareArrayVar(stubType, buffer, types::PointerUsage::PARAMETER, stub.view->getEntryValue(this));
         strMemcpy(stub.name, buffer, false);
     }
 }
@@ -396,7 +396,7 @@ void TestsPrinter::verboseOutputVariable(const Tests::MethodDescription &methodD
                types::TypesHandler::isArrayOfPointersToFunction(methodDescription.returnType)) {
         strComment("No output variable check for function returning pointer to function");
     } else if (methodDescription.returnType.isObjectPointer() &&
-               testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL) {
+               testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL) {
         strComment("No output variable check for function returning null");
     } else {
         visitor::VerboseParameterVisitor(typesHandler, this, true, types::PointerUsage::RETURN)
@@ -415,7 +415,7 @@ void TestsPrinter::verboseFunctionCall(const Tests::MethodDescription &methodDes
     std::string methodCall = constrVisitorFunctionCall(methodDescription, testCase, true);
     if (!types::TypesHandler::skipTypeInReturn(methodDescription.returnType) && !testCase.isError()) {
         size_t returnPointersCount = 0;
-        if (testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL) {
+        if (testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL) {
             returnPointersCount = methodDescription.returnType.countReturnPointers(true);
         }
         auto type = Printer::getConstQualifier(expectedType) + expectedType.usedType();
@@ -520,17 +520,17 @@ void TestsPrinter::parametrizedArrayParameters(const Tests::MethodDescription &m
                 methodDescription.getClassTypeName(), methodDescription.name, param.name);
             strDeclareArrayOfFunctionPointerVar(type, param.name, stubName);
         } else if (types::TypesHandler::isCStringType(param.type)) {
-            strDeclareArrayVar(param.type, param.name, types::PointerUsage::PARAMETER, value.view->getEntryValue(), param.alignment);
+            strDeclareArrayVar(param.type, param.name, types::PointerUsage::PARAMETER, value.view->getEntryValue(this), param.alignment);
         } else if (param.type.isObjectPointer() || param.type.isArray()) {
             auto arrayType = types::TypesHandler::isVoid(param.type.baseTypeObj())
                 ? types::Type::minimalScalarPointerType(param.type.arraysSizes(types::PointerUsage::PARAMETER).size())
                 : param.type;
             if (param.type.maybeJustPointer()) {
-                strDeclareVar(arrayType.baseType(), param.name, value.view->getEntryValue(), param.alignment);
+                strDeclareVar(arrayType.baseType(), param.name, value.view->getEntryValue(this), param.alignment);
             } else {
                 auto paramName = param.type.isTwoDimensionalPointer() ? param.underscoredName() : param.name;
                 strDeclareArrayVar(arrayType, paramName, types::PointerUsage::PARAMETER,
-                                   value.view->getEntryValue(), param.alignment, true);
+                                   value.view->getEntryValue(this), param.alignment, true);
             }
         }
         if (param.type.isTwoDimensionalPointer()) {
@@ -569,7 +569,7 @@ std::vector<std::string> TestsPrinter::methodParametersListParametrized(const Te
         } else if (!testCase.paramValues[i].lazyValues.empty()) {
             args.push_back(param.name);
         } else {
-            args.push_back(testCase.paramValues[i].view->getEntryValue());
+            args.push_back(testCase.paramValues[i].view->getEntryValue(this));
         }
     }
     return args;
@@ -607,7 +607,7 @@ std::string TestsPrinter::constrVisitorFunctionCall(const Tests::MethodDescripti
     }
     auto classObjName = methodDescription.getClassName();
     size_t returnPointersCount = 0;
-    if (testCase.returnValue.view && testCase.returnValue.view->getEntryValue() != PrinterUtils::C_NULL) {
+    if (testCase.returnValue.view && testCase.returnValue.view->getEntryValue(nullptr) != PrinterUtils::C_NULL) {
         returnPointersCount = methodDescription.returnType.countReturnPointers(true);
     }
     return constrFunctionCall(methodDescription.name, methodArgs, "", classObjName, false, returnPointersCount,
@@ -630,6 +630,27 @@ void printer::TestsPrinter::parametrizedInitializeSymbolicStubs(const Tests::Met
         const auto &value = testCase.stubValues[i];
         verboseParameter(methodDescription, param, value, false);
     }
+}
+
+std::string printer::MultiLinePrinter::print(TestsPrinter *printer,
+                                             const tests::StructValueView *view) {
+    auto subViews = view->getSubViews();
+    std::stringstream structuredValuesWithPrefixes;
+    structuredValuesWithPrefixes << "{" << NL;
+    ++printer->tabsDepth;
+    int i = 0;
+    for (const auto &sview : subViews) {
+        if (i != 0) {
+            structuredValuesWithPrefixes << "," << NL;
+        }
+        structuredValuesWithPrefixes << printer->TAB_N() << view->getFieldPrefix(i)
+                                     << sview->getEntryValue(printer);
+        ++i;
+    }
+    --printer->tabsDepth;
+    structuredValuesWithPrefixes << "}";
+
+    return structuredValuesWithPrefixes.str();
 }
 
 Tests::MethodParam printer::TestsPrinter::getValueParam(const Tests::MethodParam &param) {

--- a/server/src/printers/TestsPrinter.h
+++ b/server/src/printers/TestsPrinter.h
@@ -95,7 +95,7 @@ namespace printer {
                                  const Tests::MethodTestCase &testCase,
                                  const std::optional<LineInfo::PredicateInfo>& predicateInfo);
 
-        static std::vector<std::string>
+        std::vector<std::string>
         methodParametersListParametrized(const tests::Tests::MethodDescription &methodDescription,
                                          const Tests::MethodTestCase &testCase);
 

--- a/server/src/types/Types.h
+++ b/server/src/types/Types.h
@@ -289,6 +289,7 @@ namespace types {
 
         FPointerMap functionFields{};
         bool hasUnnamedFields;
+        bool isCLike;
     };
 
     struct UnionInfo: TypeInfo {

--- a/server/src/types/TypesResolver.cpp
+++ b/server/src/types/TypesResolver.cpp
@@ -98,6 +98,13 @@ void TypesResolver::resolveStruct(const clang::RecordDecl *D, const std::string 
     structInfo.filePath = Paths::getCCJsonFileFullPath(filename, parent->buildRootPath);
     structInfo.name = getFullname(D, canonicalType, id, sourceFilePath);
     structInfo.hasUnnamedFields = false;
+    if (Paths::getSourceLanguage(sourceFilePath) == utbot::Language::CXX) {
+        const clang::CXXRecordDecl *cppD =  dynamic_cast<const clang::CXXRecordDecl *>(D);
+        structInfo.isCLike = cppD != nullptr && cppD->isCLike();
+    }
+    else {
+        structInfo.isCLike = true;
+    }
 
     if (Paths::isGtest(structInfo.filePath)) {
         return;

--- a/server/src/visitors/AssertsVisitor.cpp
+++ b/server/src/visitors/AssertsVisitor.cpp
@@ -52,7 +52,7 @@ namespace visitor {
                                                                                  const types::Type& type,
                                                                                  const tests::AbstractValueView *view,
                                                                                  const std::string &access) {
-        if (additionalPointersCount > 0 && view->getEntryValue() == PrinterUtils::C_NULL) {
+        if (additionalPointersCount > 0 && view->getEntryValue(nullptr) == PrinterUtils::C_NULL) {
             return processExpect(type, "TRUE", {
                     PrinterUtils::fillVarName(access, PrinterUtils::ACTUAL) + " == " + PrinterUtils::C_NULL });
         }

--- a/server/src/visitors/ParametrizedAssertsVisitor.cpp
+++ b/server/src/visitors/ParametrizedAssertsVisitor.cpp
@@ -21,7 +21,7 @@ namespace visitor {
                           : methodDescription.returnType;
         functionCall = printer->constrVisitorFunctionCall(methodDescription, testCase,
                                                           false);
-        if (testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL) {
+        if (testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL) {
             additionalPointersCount = methodDescription.returnType.countReturnPointers(true);
             printer->writeCodeLine(
                     StringUtils::stringFormat("EXPECT_TRUE(%s)",
@@ -52,7 +52,7 @@ namespace visitor {
                             functionCall, std::nullopt, true, additionalPointersCount);
                     printer->strDeclareArrayVar(
                         type, PrinterUtils::fillVarName(access, PrinterUtils::EXPECTED), usage,
-                        view->getEntryValue(), std::nullopt, true);
+                        view->getEntryValue(printer), std::nullopt, true);
                 }
             } else {
                 return AbstractValueViewVisitor::visitAny(type.baseTypeObj(), name, view, access, depth);
@@ -74,12 +74,17 @@ namespace visitor {
                                                  const tests::AbstractValueView *view,
                                                  const std::string &access,
                                                  int depth) {
+        auto value = view->getEntryValue(printer);
         if (depth == 0) {
             printer->strDeclareVar(printer::Printer::getConstQualifier(type) + type.usedType(),
-                                   PrinterUtils::ACTUAL, functionCall, std::nullopt, true, additionalPointersCount);
-            printer->strDeclareVar(type.typeName(), PrinterUtils::fillVarName(access, PrinterUtils::EXPECTED), view->getEntryValue());
+                                   PrinterUtils::ACTUAL, functionCall, std::nullopt, true,
+                                   additionalPointersCount);
+            printer->strDeclareVar(
+                type.typeName(), PrinterUtils::fillVarName(access, PrinterUtils::EXPECTED), value);
         }
-        AbstractValueViewVisitor::visitStruct(type, name, view, access, depth);
+        else {
+            printer->ss << value << NL;
+        }
     }
 
     void ParametrizedAssertsVisitor::visitUnion(const types::Type &type,
@@ -90,9 +95,11 @@ namespace visitor {
         if (depth == 0) {
             printer->strDeclareVar(printer::Printer::getConstQualifier(type) + type.usedType(),
                                    PrinterUtils::ACTUAL, functionCall, std::nullopt, true, additionalPointersCount);
-            printer->strDeclareVar(type.typeName(), PrinterUtils::EXPECTED, view->getEntryValue());
+            printer->strDeclareVar(type.typeName(), PrinterUtils::EXPECTED, view->getEntryValue(printer));
         }
-        AbstractValueViewVisitor::visitUnion(type, name, view, access, depth);
+        else {
+            AbstractValueViewVisitor::visitUnion(type, name, view, access, depth);
+        }
     }
 
     void ParametrizedAssertsVisitor::visitPrimitive(const types::Type &type,
@@ -109,7 +116,7 @@ namespace visitor {
                                        additionalPointersCount);
                 const auto &gtestMacro = predicateMapping.at(predicate);
                 auto signature =
-                        processExpect(type, gtestMacro, {view->getEntryValue(), getDecorateActualVarName(access)});
+                        processExpect(type, gtestMacro, {view->getEntryValue(printer), getDecorateActualVarName(access)});
                 signature = changeSignatureToNullCheck(signature, type, view, access);
                 printer->strFunctionCall(signature.name, signature.args, SCNL, std::nullopt, true, 0,
                                          std::nullopt, inUnion);

--- a/server/src/visitors/VerboseAssertsReturnValueVisitor.cpp
+++ b/server/src/visitors/VerboseAssertsReturnValueVisitor.cpp
@@ -16,7 +16,7 @@ namespace visitor {
         auto returnType = methodDescription.returnType.maybeReturnArray()
                               ? methodDescription.returnType.arrayClone(usage, pointerSize)
                               : methodDescription.returnType.baseTypeObj();
-        if (testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL) {
+        if (testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL) {
             additionalPointersCount = methodDescription.returnType.countReturnPointers(true);
             printer->writeCodeLine(StringUtils::stringFormat("EXPECT_TRUE(%s" + PrinterUtils::EQ_OPERATOR + PrinterUtils::C_NULL + ")", PrinterUtils::ACTUAL));
             return;

--- a/server/src/visitors/VerboseParameterVisitor.cpp
+++ b/server/src/visitors/VerboseParameterVisitor.cpp
@@ -35,11 +35,11 @@ namespace visitor {
                                                int depth) {
         if (depth == 0) {
             if (needDeclaration) {
-                printer->strDeclareArrayVar(type, name, usage, view->getEntryValue(), parameterAlignment);
+                printer->strDeclareArrayVar(type, name, usage, view->getEntryValue(printer), parameterAlignment);
             } else {
                 static const std::string bufferSuffix = "_buffer";
                 std::string buffer = name + bufferSuffix;
-                printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue());
+                printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue(printer));
                 size_t size = types::TypesHandler::getElementsNumberInPointerOneDim(usage);
                 std::string callocCall = StringUtils::stringFormat("(%s) calloc(%zu, sizeof(%s))",
                                                               type.usedType(), size, type.baseType());
@@ -47,7 +47,7 @@ namespace visitor {
                 printer->strMemcpy(name, buffer, false);
             }
         } else {
-            printer->strAssignVar(name, view->getEntryValue());
+            printer->strAssignVar(name, view->getEntryValue(printer));
         }
     }
 
@@ -58,11 +58,11 @@ namespace visitor {
                                              size_t size,
                                              int depth) {
         if (needDeclaration) {
-            printer->strDeclareArrayVar(type, name, usage, view->getEntryValue(), parameterAlignment);
+            printer->strDeclareArrayVar(type, name, usage, view->getEntryValue(printer), parameterAlignment);
         } else {
             std::string bufferSuffix = "_buffer";
             std::string buffer = name + bufferSuffix;
-            printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue(), parameterAlignment);
+            printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue(printer), parameterAlignment);
             printer->strMemcpy(name, buffer, false);
         }
 
@@ -75,7 +75,7 @@ namespace visitor {
                                                int depth) {
         std::string bufferSuffix = "_buffer";
         std::string buffer = name + bufferSuffix;
-        printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue(), parameterAlignment);
+        printer->strDeclareArrayVar(type, buffer, usage, view->getEntryValue(printer), parameterAlignment);
         if (needDeclaration) {
             printer->strDeclareVar(type.usedType(), name, buffer);
         } else {
@@ -88,23 +88,24 @@ namespace visitor {
                                               const tests::AbstractValueView *view,
                                               const std::string &access,
                                               int depth) {
+        auto value = view->getEntryValue(printer);
         if (depth == 0) {
-            auto value = view->getEntryValue();
             if (needDeclaration) {
                 printer->strDeclareVar(type.usedType(), name, value, parameterAlignment);
             } else {
                 printer->strAssignVar(name, value);
             }
         } else {
-            AbstractValueViewVisitor::visitStruct(type, name, view, access, depth);
+            printer->ss << value << NL;
         }
     }
+
     void VerboseParameterVisitor::visitUnion(const types::Type &type,
                                              const std::string &name,
                                              const tests::AbstractValueView *view,
                                              const std::string &access,
                                              int depth) {
-        auto value = view->getEntryValue();
+        auto value = view->getEntryValue(printer);
         if (depth == 0) {
             if (needDeclaration) {
                 printer->strDeclareVar(type.usedType(), name, value, parameterAlignment);
@@ -121,7 +122,7 @@ namespace visitor {
                                                  const std::string &access,
                                                  int depth) {
         const auto typeName = types::TypesHandler::cBoolToCpp(type.usedType());
-        auto value = view->getEntryValue();
+        auto value = view->getEntryValue(printer);
         if (depth == 0) {
             if (needDeclaration) {
                 printer->strDeclareVar(typeName, name, value, parameterAlignment);

--- a/server/test/framework/Library_Test.cpp
+++ b/server/test/framework/Library_Test.cpp
@@ -43,10 +43,10 @@ namespace {
             testGen.tests.at(test_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({
                 [](const tests::Tests::MethodTestCase &testCase) {
-                     return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                     return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                  },
                 [](const tests::Tests::MethodTestCase &testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                 }
             })
         );
@@ -59,10 +59,10 @@ namespace {
             testGen2.tests.at(test_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({
                 [](const tests::Tests::MethodTestCase &testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                 [](const tests::Tests::MethodTestCase &testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                 }
             })
         );

--- a/server/test/framework/Regression_Tests.cpp
+++ b/server/test/framework/Regression_Tests.cpp
@@ -53,8 +53,8 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(helloworld_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
-                int ret = stoi(testCase.returnValue.view->getEntryValue());
-                int param = stoi(testCase.paramValues[0].view->getEntryValue());
+                int ret = stoi(testCase.returnValue.view->getEntryValue(nullptr));
+                int param = stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
                 return ret == param + 1;
             } }),
             "helloworld");
@@ -71,7 +71,7 @@ namespace {
             checkTestCasePredicates(
                 testGen.tests.at(source).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
-                    return testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL;
+                    return testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL;
                 } }),
                 "byword");
         }

--- a/server/test/framework/Server_Tests.cpp
+++ b/server/test/framework/Server_Tests.cpp
@@ -125,10 +125,10 @@ namespace {
                 testGen.tests.at(assertion_failures_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                     { [](tests::Tests::MethodTestCase const &testCase) {
-                         return stoi(testCase.paramValues[0].view->getEntryValue()) < 7;
+                         return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 7;
                      },
                       [](tests::Tests::MethodTestCase const &testCase) {
-                          return stoi(testCase.paramValues[0].view->getEntryValue()) == 7;
+                          return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 7;
                       } }),
                 "buggy_function2");
         }
@@ -143,17 +143,17 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) >
-                                            stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                        stoi(testCase.returnValue.view->getEntryValue()) ==
-                                            stoi(testCase.paramValues[0].view->getEntryValue()) &&
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >
+                                            stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                        stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                            stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) &&
                                         testCase.stdinValue == std::nullopt;
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return stoi(testCase.paramValues[0].view->getEntryValue()) <=
-                                             stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                         stoi(testCase.returnValue.view->getEntryValue()) ==
-                                             stoi(testCase.paramValues[1].view->getEntryValue()) &&
+                                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) <=
+                                             stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                         stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                             stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
                                          testCase.stdinValue == std::nullopt;
                               } }),
                         methodName);
@@ -162,16 +162,16 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 &&
-                                        stoi(testCase.returnValue.view->getEntryValue()) == -1 &&
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 &&
+                                        stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1 &&
                                         testCase.stdinValue == std::nullopt;
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return stoi(testCase.paramValues[0].view->getEntryValue()) >= 0 &&
-                                         stoi(testCase.returnValue.view->getEntryValue()) ==
-                                             stoi(testCase.paramValues[0].view->getEntryValue()) *
+                                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >= 0 &&
+                                         stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                             stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) *
                                                  stoi(testCase.paramValues[0]
-                                                          .view->getEntryValue()) &&
+                                                          .view->getEntryValue(nullptr)) &&
                                          testCase.stdinValue == std::nullopt;
                               } }),
                         methodName);
@@ -180,15 +180,15 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 return testCase.returnValue.view->getEntryValue() == "0" &&
+                                 return testCase.returnValue.view->getEntryValue(nullptr) == "0" &&
                                         testCase.stdinValue == std::nullopt;
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return testCase.returnValue.view->getEntryValue() == "1" &&
+                                  return testCase.returnValue.view->getEntryValue(nullptr) == "1" &&
                                          testCase.stdinValue == std::nullopt;
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return testCase.returnValue.view->getEntryValue() == "2" &&
+                                  return testCase.returnValue.view->getEntryValue(nullptr) == "2" &&
                                          testCase.stdinValue == std::nullopt;
                               } }),
                         methodName);
@@ -201,16 +201,16 @@ namespace {
                 testGen.tests.at(dependent_functions_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                     { [](tests::Tests::MethodTestCase const &testCase) {
-                         return stoi(testCase.paramValues[0].view->getEntryValue()) >
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                stoi(testCase.returnValue.view->getEntryValue()) ==
-                                    stoi(testCase.paramValues[0].view->getEntryValue()) * 2;
+                         return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                    stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) * 2;
                      },
                       [](tests::Tests::MethodTestCase const &testCase) {
-                          return stoi(testCase.paramValues[0].view->getEntryValue()) <=
-                                     stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                 stoi(testCase.returnValue.view->getEntryValue()) ==
-                                     stoi(testCase.paramValues[1].view->getEntryValue()) * 2;
+                          return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) <=
+                                     stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                 stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                     stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) * 2;
                       } }),
                 "double_max");
         }
@@ -223,13 +223,13 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>({
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "0";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "0";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "-1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "-1";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "1";
                             },
                         }),
                         methodName);
@@ -241,23 +241,23 @@ namespace {
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
                                  return testUtils::cmpChars(
-                                     testCase.returnValue.view->getEntryValue(), 'a');
+                                     testCase.returnValue.view->getEntryValue(nullptr), 'a');
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'c');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'c');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'u');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'u');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), '1');
+                                      testCase.returnValue.view->getEntryValue(nullptr), '1');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), '0');
+                                      testCase.returnValue.view->getEntryValue(nullptr), '0');
                               } }),
                         methodName);
                 } else if (methodName == "operate_with_inner_structs") {
@@ -266,19 +266,19 @@ namespace {
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
                                  return testUtils::cmpChars(
-                                     testCase.returnValue.view->getEntryValue(), '5');
+                                     testCase.returnValue.view->getEntryValue(nullptr), '5');
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'e');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'e');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'g');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'g');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'o');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'o');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) { return true; } }),
                         methodName);
@@ -296,13 +296,13 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>({
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "0";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "0";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "-1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "-1";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "1";
                             },
                         }),
                         methodName);
@@ -312,13 +312,13 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>({
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "0";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "0";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "-1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "-1";
                             },
                             [](tests::Tests::MethodTestCase const &testCase) {
-                                return testCase.returnValue.view->getEntryValue() == "1";
+                                return testCase.returnValue.view->getEntryValue(nullptr) == "1";
                             },
                         }),
                         methodName);
@@ -331,7 +331,7 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                int i = stoi(testCase.paramValues[1].view->getEntryValue());
+                                int i = stoi(testCase.paramValues[1].view->getEntryValue(nullptr));
                                 return i >= 0 && i < 2;
                             } }),
                         methodName);
@@ -342,35 +342,35 @@ namespace {
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
                                  return testUtils::cmpChars(
-                                     testCase.returnValue.view->getEntryValue(), '5');
+                                     testCase.returnValue.view->getEntryValue(nullptr), '5');
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), '5');
+                                      testCase.returnValue.view->getEntryValue(nullptr), '5');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), '5');
+                                      testCase.returnValue.view->getEntryValue(nullptr), '5');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'e');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'e');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'f');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'f');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'g');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'g');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), 'o');
+                                      testCase.returnValue.view->getEntryValue(nullptr), 'o');
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
                                   return testUtils::cmpChars(
-                                      testCase.returnValue.view->getEntryValue(), '\x0f');
+                                      testCase.returnValue.view->getEntryValue(nullptr), '\x0f');
                               } }),
                         methodName);
                 }
@@ -393,16 +393,16 @@ namespace {
                         methodDescription.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 return testCase.returnValue.view->getEntryValue() ==
-                                        testCase.paramValues[0].view->getEntryValue();
+                                 return testCase.returnValue.view->getEntryValue(nullptr) ==
+                                        testCase.paramValues[0].view->getEntryValue(nullptr);
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return testCase.returnValue.view->getEntryValue() ==
-                                         testCase.paramValues[2].view->getEntryValue();
+                                  return testCase.returnValue.view->getEntryValue(nullptr) ==
+                                         testCase.paramValues[2].view->getEntryValue(nullptr);
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  return testCase.returnValue.view->getEntryValue() ==
-                                         testCase.paramValues[1].view->getEntryValue();
+                                  return testCase.returnValue.view->getEntryValue(nullptr) ==
+                                         testCase.paramValues[1].view->getEntryValue(nullptr);
                               } }),
                         methodName);
                 }
@@ -469,7 +469,7 @@ namespace {
                  testGen.tests.at(floating_point_c).methods) {
                 std::unordered_set<std::string> completeness;
                 for (const auto &testCase : methodDescription.testCases) {
-                    completeness.insert(testCase.returnValue.view->getEntryValue());
+                    completeness.insert(testCase.returnValue.view->getEntryValue(nullptr));
                 }
                 if (methodName == "get_double_sign") {
                     EXPECT_GE(methodDescription.testCases.size(), 3);
@@ -498,7 +498,7 @@ namespace {
                 if (methodName == "plain_isnan") {
                     std::unordered_set<std::string> completeness;
                     for (const auto &testCase : methodDescription.testCases) {
-                        completeness.insert(testCase.returnValue.view->getEntryValue());
+                        completeness.insert(testCase.returnValue.view->getEntryValue(nullptr));
                     }
                     EXPECT_GE(methodDescription.testCases.size(), 2);
                     EXPECT_GE(completeness.size(), 2);
@@ -526,9 +526,9 @@ namespace {
                         md.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                auto returnValue = testCase.returnValue.view->getEntryValue();
-                                auto preValue = testCase.globalPreValues[0].view->getEntryValue();
-                                auto postValue = testCase.globalPostValues[0].view->getEntryValue();
+                                auto returnValue = testCase.returnValue.view->getEntryValue(nullptr);
+                                auto preValue = testCase.globalPreValues[0].view->getEntryValue(nullptr);
+                                auto postValue = testCase.globalPostValues[0].view->getEntryValue(nullptr);
                                 return returnValue == postValue &&
                                        stoi(preValue) + 1 == stoi(postValue);
                             } }));
@@ -560,7 +560,7 @@ namespace {
                                             std::vector<TestCasePredicate>(
                                                 { [](tests::Tests::MethodTestCase const &testCase) {
                                                     auto returnValue =
-                                                        testCase.returnValue.view->getEntryValue();
+                                                        testCase.returnValue.view->getEntryValue(nullptr);
                                                     return returnValue == "256";
                                                 } }));
                 } else if (md.name == "stop_now") {
@@ -568,11 +568,11 @@ namespace {
                         md.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 auto i = testCase.paramValues[0].view->getEntryValue();
+                                 auto i = testCase.paramValues[0].view->getEntryValue(nullptr);
                                  return i == "0";
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  auto i = testCase.paramValues[0].view->getEntryValue();
+                                  auto i = testCase.paramValues[0].view->getEntryValue(nullptr);
                                   return stoi(i) > 0;
                               } }));
                 } else if (md.name == "and") {
@@ -580,9 +580,9 @@ namespace {
                         md.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                auto x = testCase.paramValues[0].view->getEntryValue();
-                                auto y = testCase.paramValues[1].view->getEntryValue();
-                                auto z = testCase.returnValue.view->getEntryValue();
+                                auto x = testCase.paramValues[0].view->getEntryValue(nullptr);
+                                auto y = testCase.paramValues[1].view->getEntryValue(nullptr);
+                                auto z = testCase.returnValue.view->getEntryValue(nullptr);
                                 return (stoi(x) & stoi(y)) == stoi(z);
                             } }));
                 } else if (md.name == "using") {
@@ -604,15 +604,15 @@ namespace {
                         md.testCases,
                         std::vector<TestCasePredicate>(
                             { [](tests::Tests::MethodTestCase const &testCase) {
-                                 auto i = testCase.paramValues[0].view->getEntryValue();
+                                 auto i = testCase.paramValues[0].view->getEntryValue(nullptr);
                                  return i == "private_";
                              },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  auto i = testCase.paramValues[0].view->getEntryValue();
+                                  auto i = testCase.paramValues[0].view->getEntryValue(nullptr);
                                   return i == "protected_";
                               },
                               [](tests::Tests::MethodTestCase const &testCase) {
-                                  auto i = testCase.paramValues[0].view->getEntryValue();
+                                  auto i = testCase.paramValues[0].view->getEntryValue(nullptr);
                                   return i == "public_";
                               } }));
                 }
@@ -676,8 +676,8 @@ namespace {
             checkTestCasePredicates(
                 testGen.tests.at(main_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return stoi(testCase.paramValues[0].view->getEntryValue()) - 2 ==
-                           stoi(testCase.returnValue.view->getEntryValue());
+                    return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) - 2 ==
+                           stoi(testCase.returnValue.view->getEntryValue(nullptr));
                 } }));
         }
         {
@@ -693,8 +693,8 @@ namespace {
             checkTestCasePredicates(
                 testGen.tests.at(a_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return stoi(testCase.paramValues[0].view->getEntryValue()) + 1 ==
-                           stoi(testCase.returnValue.view->getEntryValue());
+                    return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) + 1 ==
+                           stoi(testCase.returnValue.view->getEntryValue(nullptr));
                 } }));
         }
         {
@@ -710,8 +710,8 @@ namespace {
             checkTestCasePredicates(
                 testGen.tests.at(b_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return stoi(testCase.paramValues[0].view->getEntryValue()) - 1 ==
-                           stoi(testCase.returnValue.view->getEntryValue());
+                    return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) - 1 ==
+                           stoi(testCase.returnValue.view->getEntryValue(nullptr));
                 } }));
         }
 
@@ -735,7 +735,7 @@ namespace {
                 EXPECT_EQ(md.testCases.size(), 1);
             } else if (md.name == "FOO_FUNCTION_1") {
                 auto inBounds = [](tests::Tests::MethodTestCase const &testCase) {
-                    auto type = testCase.paramValues[0].view->getEntryValue();
+                    auto type = testCase.paramValues[0].view->getEntryValue(nullptr);
                     return stoi(type) >= 0 && stoi(type) < 3;
                 };
                 auto hasGlobalParameter = [](tests::Tests::MethodTestCase const &testCase) {
@@ -1018,8 +1018,8 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(basic_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 &&
-                       stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 &&
+                       stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                 } }),
             "sqr_positive");
     }
@@ -1035,9 +1035,9 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(basic_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                return stoi(testCase.returnValue.view->getEntryValue()) ==
-                       stoi(testCase.paramValues[0].view->getEntryValue()) *
-                           stoi(testCase.paramValues[0].view->getEntryValue());
+                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                       stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) *
+                           stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
             } }),
             "sqr_positive");
     }
@@ -1053,7 +1053,7 @@ namespace {
         checkTestCasePredicates(
                 testGen.tests.at(multiple_classes_cpp).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return testCase.returnValue.view->getEntryValue() == "1";} }),
+                    return testCase.returnValue.view->getEntryValue(nullptr) == "1";} }),
                 "get1");
     }
 
@@ -1068,7 +1068,7 @@ namespace {
         checkTestCasePredicates(
                 testGen.tests.at(multiple_classes_cpp).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return testCase.returnValue.view->getEntryValue() == "2";} }),
+                    return testCase.returnValue.view->getEntryValue(nullptr) == "2";} }),
                 "get2");
     }
 
@@ -1083,7 +1083,7 @@ namespace {
         checkTestCasePredicates(
                 testGen.tests.at(multiple_classes_cpp).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                    return testCase.returnValue.view->getEntryValue() == "2";} }),
+                    return testCase.returnValue.view->getEntryValue(nullptr) == "2";} }),
                 "get3");
     }
 
@@ -1101,16 +1101,16 @@ namespace {
             testGen.tests.at(basic_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 { [](tests::Tests::MethodTestCase const &testCase) {
-                     return stoi(testCase.paramValues[0].view->getEntryValue()) >
-                                stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                            stoi(testCase.returnValue.view->getEntryValue()) ==
-                                stoi(testCase.paramValues[0].view->getEntryValue());
+                     return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >
+                                stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                            stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
                  },
                   [](tests::Tests::MethodTestCase const &testCase) {
-                      return stoi(testCase.paramValues[0].view->getEntryValue()) <=
-                                 stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                             stoi(testCase.returnValue.view->getEntryValue()) ==
-                                 stoi(testCase.paramValues[1].view->getEntryValue());
+                      return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) <=
+                                 stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                             stoi(testCase.returnValue.view->getEntryValue(nullptr)) ==
+                                 stoi(testCase.paramValues[1].view->getEntryValue(nullptr));
                   } }),
             "max_");
     }
@@ -1133,7 +1133,7 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(basic_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                return testCase.paramValues[0].view->getEntryValue() == "6";
+                return testCase.paramValues[0].view->getEntryValue(nullptr) == "6";
             } }),
             "sqr_positive");
     }
@@ -1156,7 +1156,7 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(basic_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](tests::Tests::MethodTestCase const &testCase) {
-                return testCase.returnValue.view->getEntryValue() == "\"abacaba\"";
+                return testCase.returnValue.view->getEntryValue(nullptr) == "\"abacaba\"";
             } }),
             "const_str");
     }
@@ -1175,7 +1175,7 @@ namespace {
         bool foundPath = false;
         for (const auto &testCase :
             testGen.tests.at(symbolic_stdin_c).methods.begin().value().testCases) {
-            foundPath |= (testCase.returnValue.view->getEntryValue() == "1");
+            foundPath |= (testCase.returnValue.view->getEntryValue(nullptr) == "1");
             if (foundPath) {
                 break;
             }

--- a/server/test/framework/Stub_Tests.cpp
+++ b/server/test/framework/Stub_Tests.cpp
@@ -198,23 +198,23 @@ namespace {
             methods.at("check_stubs").testCases,
             std::vector<TestCasePredicate>({
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "1";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "2";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "3";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "4";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "5";
                 }}),
             "check_stubs");
@@ -255,19 +255,19 @@ namespace {
             methods.at("check_stubs").testCases,
             std::vector<TestCasePredicate>({
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "1";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "2";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "3";
                 },
                 [](tests::Tests::MethodTestCase const &testCase) {
-                    auto result = testCase.returnValue.view->getEntryValue();
+                    auto result = testCase.returnValue.view->getEntryValue(nullptr);
                     return result == "4";
                 }}),
             "check_stubs");

--- a/server/test/framework/Syntax_Tests.cpp
+++ b/server/test/framework/Syntax_Tests.cpp
@@ -7,6 +7,7 @@
 #include "BaseTest.h"
 #include "KleeGenerator.h"
 #include "Server.h"
+#include "TestUtils.h"
 #include "streams/coverage/ServerCoverageAndResultsWriter.h"
 #include "coverage/CoverageAndResultsGenerator.h"
 
@@ -104,9 +105,10 @@ namespace {
         printer::TestsPrinter testsPrinter(nullptr, utbot::Language::C);
         const auto &tests = testGen.tests.at(simple_structs_c)
                                 .methods.begin().value().testCases.begin();
-        ASSERT_EQ("{"
-                  "\n    .x = 0,"
-                  "\n    .a = 2}", tests[0].paramValues[0].view->getEntryValue(&testsPrinter));
+        testUtils::checkRegexp(tests[0].paramValues[0].view->getEntryValue(&testsPrinter),
+                               "[{]"
+                               "\n    [.]x = .+[,]"
+                               "\n    [.]a = .+[}]");
 
         ASSERT_TRUE(status.ok()) << status.error_message();
         checkTestCasePredicates(
@@ -165,15 +167,16 @@ namespace {
         printer::TestsPrinter testsPrinter(nullptr, utbot::Language::C);
         const auto &tests = testGen.tests.at(simple_structs_c)
                 .methods.begin().value().testCases.begin();
-        ASSERT_EQ("{"
-                  "\n    .inner = {"
-                  "\n        .c = '2',"
-                  "\n        .ininner = {"
-                  "\n            .u = 2U,"
-                  "\n            .l = 2LL},"
-                  "\n        .s = 2},"
-                  "\n    .x = 2,"
-                  "\n    .y = 2LL}", tests[0].returnValue.view->getEntryValue(&testsPrinter));
+        testUtils::checkRegexp(tests[0].returnValue.view->getEntryValue(&testsPrinter),
+                               "[{]"
+                               "\n    [.]inner = [{]"
+                               "\n        [.]c = ['].+['][,]"
+                               "\n        [.]ininner = [{]"
+                               "\n            [.]u = .+U[,]"
+                               "\n            [.]l = .+LL[}][,]"
+                               "\n        [.]s = .+[}][,]"
+                               "\n    [.]x = .+[,]"
+                               "\n    [.]y = .+LL[}]");
 
         checkTestCasePredicates(
                 testGen.tests.at(simple_structs_c).methods.begin().value().testCases,
@@ -2401,9 +2404,10 @@ namespace {
         printer::TestsPrinter testsPrinter(nullptr, utbot::Language::CXX);
         const auto &tests = testGen.tests.at(simple_class_cpp)
                                 .methods.begin().value().testCases.begin();
-        ASSERT_EQ("{"
-                  "\n    /*.x = */-1,"
-                  "\n    /*.y = */2}", tests[0].paramValues[0].view->getEntryValue(&testsPrinter));
+        testUtils::checkRegexp(tests[0].paramValues[0].view->getEntryValue(&testsPrinter),
+                               "[{]"
+                               "\n    /[*][.]x = [*]/.+[,]"
+                               "\n    /[*][.]y = [*]/.+[}]");
 
         testUtils::checkMinNumberOfTests(testGen.tests.at(simple_class_cpp).methods.begin().value().testCases, 5);
 

--- a/server/test/framework/Syntax_Tests.cpp
+++ b/server/test/framework/Syntax_Tests.cpp
@@ -64,16 +64,16 @@ namespace {
                     testGen.tests.at(enums_c).methods.begin().value().testCases,
                     std::vector<TestCasePredicate>(
                             {[] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.paramValues[0].view->getEntryValue()) == 0
-                                    && testCase.returnValue.view->getEntryValue() == "ZERO";
+                                return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0
+                                    && testCase.returnValue.view->getEntryValue(nullptr) == "ZERO";
                             },
                              [] (const tests::Tests::MethodTestCase& testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) > 0
-                                    && testCase.returnValue.view->getEntryValue() == "POSITIVE";
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0
+                                    && testCase.returnValue.view->getEntryValue(nullptr) == "POSITIVE";
                              },
                              [] (const tests::Tests::MethodTestCase& testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) < 0
-                                    && testCase.returnValue.view->getEntryValue() == "NEGATIVE";
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0
+                                    && testCase.returnValue.view->getEntryValue(nullptr) == "NEGATIVE";
                              }
                             }
                     )
@@ -101,23 +101,29 @@ namespace {
     TEST_F(Syntax_Test, Struct_Parameter_Test_1) {
         auto [testGen, status] = createTestForFunction(simple_structs_c, 9);
 
-        ASSERT_TRUE(status.ok()) << status.error_message();
+        printer::TestsPrinter testsPrinter(nullptr, utbot::Language::C);
+        const auto &tests = testGen.tests.at(simple_structs_c)
+                                .methods.begin().value().testCases.begin();
+        ASSERT_EQ("{"
+                  "\n    .x = 0,"
+                  "\n    .a = 2}", tests[0].paramValues[0].view->getEntryValue(&testsPrinter));
 
+        ASSERT_TRUE(status.ok()) << status.error_message();
         checkTestCasePredicates(
                 testGen.tests.at(simple_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.returnValue.view->getEntryValue()) == 0
-                                && testCase.paramValues[0].view->getEntryValue().find(", 0}") != std::string::npos;
+                            return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find(", 0}") != std::string::npos;
                             },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == -1
-                                && testCase.paramValues[0].view->getEntryValue().find(", -") != std::string::npos;
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find(", -") != std::string::npos;
                             },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == 1
-                                && testCase.paramValues[0].view->getEntryValue().find(", -") == std::string::npos
-                                    && testCase.paramValues[0].view->getEntryValue().find(", 0}") == std::string::npos;
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find(", -") == std::string::npos
+                                    && testCase.paramValues[0].view->getEntryValue(nullptr).find(", 0}") == std::string::npos;
                          }
                         }),
                 "get_sign_struct");
@@ -133,19 +139,19 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'a');
+                            return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'a');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'c');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'c');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'u');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'u');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '1');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '1');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '0');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '0');
                          },
                         }),
                 "get_symbol_by_struct");
@@ -156,21 +162,34 @@ namespace {
 
         ASSERT_TRUE(status.ok()) << status.error_message();
 
+        printer::TestsPrinter testsPrinter(nullptr, utbot::Language::C);
+        const auto &tests = testGen.tests.at(simple_structs_c)
+                .methods.begin().value().testCases.begin();
+        ASSERT_EQ("{"
+                  "\n    .inner = {"
+                  "\n        .c = '2',"
+                  "\n        .ininner = {"
+                  "\n            .u = 2U,"
+                  "\n            .l = 2LL},"
+                  "\n        .s = 2},"
+                  "\n    .x = 2,"
+                  "\n    .y = 2LL}", tests[0].returnValue.view->getEntryValue(&testsPrinter));
+
         checkTestCasePredicates(
                 testGen.tests.at(simple_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) == 0
-                               && testCase.returnValue.view->getEntryValue() == "{{'0', {0U, 0LL}, 0}, 0, 0LL}";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0
+                               && testCase.returnValue.view->getEntryValue(nullptr) == "{{'0', {0U, 0LL}, 0}, 0, 0LL}";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) == 1
-                               && testCase.returnValue.view->getEntryValue() == "{{'1', {1U, 1LL}, 1}, 1, 1LL}";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 1
+                               && testCase.returnValue.view->getEntryValue(nullptr) == "{{'1', {1U, 1LL}, 1}, 1, 1LL}";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) != 0
-                               && stoi(testCase.paramValues[0].view->getEntryValue()) != 1
-                                && testCase.returnValue.view->getEntryValue() == "{{'2', {2U, 2LL}, 2}, 2, 2LL}";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 0
+                               && stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 1
+                                && testCase.returnValue.view->getEntryValue(nullptr) == "{{'2', {2U, 2LL}, 2}, 2, 2LL}";
                          },
                         }),
                 "struct_as_return_type");
@@ -187,16 +206,16 @@ namespace {
                 testGen.tests.at(simple_unions_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.returnValue.view->getEntryValue()) == 0 &&
-                                testCase.paramValues[0].view->getEntryValue() == "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
+                            return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0 &&
+                                testCase.paramValues[0].view->getEntryValue(nullptr) == "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == -1 &&
-                                testCase.paramValues[0].view->getEntryValue() != "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1 &&
+                                testCase.paramValues[0].view->getEntryValue(nullptr) != "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
                          },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == 1 &&
-                                testCase.paramValues[0].view->getEntryValue() != "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1 &&
+                                testCase.paramValues[0].view->getEntryValue(nullptr) != "from_bytes<IntBytesUnion>({0, 0, 0, 0})";
                          }
                         }),
                 "get_sign_union");
@@ -212,16 +231,16 @@ namespace {
                 testGen.tests.at(simple_unions_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.returnValue.view->getEntryValue()) == 1
-                                && testCase.paramValues[0].view->getEntryValue().find("from_bytes<ShortBytesUnion>({0, ") == 0;
+                            return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find("from_bytes<ShortBytesUnion>({0, ") == 0;
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == 0
-                                && testCase.paramValues[0].view->getEntryValue().find("from_bytes<ShortBytesUnion>({0, ") == std::string::npos;
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find("from_bytes<ShortBytesUnion>({0, ") == std::string::npos;
                          },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == -1
-                                && testCase.paramValues[0].view->getEntryValue().find("from_bytes<ShortBytesUnion>({0, 0}") == 0;
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1
+                                && testCase.paramValues[0].view->getEntryValue(nullptr).find("from_bytes<ShortBytesUnion>({0, 0}") == 0;
                          }
                         }),
                 "extract_bit");
@@ -236,17 +255,17 @@ namespace {
                 testGen.tests.at(simple_unions_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) == 0
-                               && testCase.returnValue.view->getEntryValue() == "from_bytes<MainUnion>({48, 0, 0, 0, 0, 0, 0, 0})";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0
+                               && testCase.returnValue.view->getEntryValue(nullptr) == "from_bytes<MainUnion>({48, 0, 0, 0, 0, 0, 0, 0})";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) == 1
-                               && testCase.returnValue.view->getEntryValue() == "from_bytes<MainUnion>({1, 0, 0, 0, 0, 0, 0, 0})";
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 1
+                               && testCase.returnValue.view->getEntryValue(nullptr) == "from_bytes<MainUnion>({1, 0, 0, 0, 0, 0, 0, 0})";
                          },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) != 0
-                               && stoi(testCase.paramValues[0].view->getEntryValue()) != 1
-                                && testCase.returnValue.view->getEntryValue() == "from_bytes<MainUnion>({2, 0, 0, 0, 0, 0, 0, 0})";
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 0
+                               && stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 1
+                                && testCase.returnValue.view->getEntryValue(nullptr) == "from_bytes<MainUnion>({2, 0, 0, 0, 0, 0, 0, 0})";
                          },
                         }),
                 "union_as_return_type");
@@ -265,7 +284,7 @@ namespace {
                             int cnt = 0;
                             auto const &str = testCase.paramValues[0];
                             const char *substr = "}),";
-                            while ((it = str.view->getEntryValue().find(substr, it)) != std::string::npos) {
+                            while ((it = str.view->getEntryValue(nullptr).find(substr, it)) != std::string::npos) {
                                 cnt++;
                                 it++;
                             }
@@ -281,7 +300,7 @@ namespace {
         checkTestCasePredicates(
             testGen.tests.at(simple_unions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
-                return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
             } }),
             "operateWithUnionWithPointer");
     }
@@ -295,12 +314,12 @@ namespace {
                 testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoll(testCase.paramValues[0].view->getEntryValue()) < stoll(testCase.paramValues[1].view->getEntryValue())
-                                && stoll(testCase.paramValues[0].view->getEntryValue()) == stoll(testCase.returnValue.view->getEntryValue());
+                            return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoll(testCase.paramValues[1].view->getEntryValue(nullptr))
+                                && stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) == stoll(testCase.returnValue.view->getEntryValue(nullptr));
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoll(testCase.paramValues[0].view->getEntryValue()) >= stoll(testCase.paramValues[1].view->getEntryValue())
-                                && stoll(testCase.paramValues[1].view->getEntryValue()) == stoll(testCase.returnValue.view->getEntryValue());
+                             return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoll(testCase.paramValues[1].view->getEntryValue(nullptr))
+                                && stoll(testCase.paramValues[1].view->getEntryValue(nullptr)) == stoll(testCase.returnValue.view->getEntryValue(nullptr));
                          }
                         }),
                 "returns_pointer_with_min");
@@ -315,14 +334,14 @@ namespace {
                 testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoll(testCase.paramValues[0].view->getEntryValue()) < stoll(testCase.paramValues[1].view->getEntryValue())
-                                && "{" + testCase.paramValues[0].view->getEntryValue() + ", " + testCase.paramValues[1].view->getEntryValue() + "}"
-                                    == testCase.returnValue.view->getEntryValue();
+                            return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoll(testCase.paramValues[1].view->getEntryValue(nullptr))
+                                && "{" + testCase.paramValues[0].view->getEntryValue(nullptr) + ", " + testCase.paramValues[1].view->getEntryValue(nullptr) + "}"
+                                    == testCase.returnValue.view->getEntryValue(nullptr);
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoll(testCase.paramValues[0].view->getEntryValue()) >= stoll(testCase.paramValues[1].view->getEntryValue())
-                                && "{" + testCase.paramValues[1].view->getEntryValue() + ", " + testCase.paramValues[0].view->getEntryValue() + "}"
-                                    == testCase.returnValue.view->getEntryValue();
+                             return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoll(testCase.paramValues[1].view->getEntryValue(nullptr))
+                                && "{" + testCase.paramValues[1].view->getEntryValue(nullptr) + ", " + testCase.paramValues[0].view->getEntryValue(nullptr) + "}"
+                                    == testCase.returnValue.view->getEntryValue(nullptr);
                          }
                         }),
                 "returns_struct_with_min_max");
@@ -336,8 +355,8 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                auto entryValue = testCase.paramValues[0].view->getEntryValue();
-                auto returnValue = stoll(testCase.returnValue.view->getEntryValue());
+                auto entryValue = testCase.paramValues[0].view->getEntryValue(nullptr);
+                auto returnValue = stoll(testCase.returnValue.view->getEntryValue(nullptr));
                 return static_cast<unsigned char>(entryValue[1]) ==
                        static_cast<unsigned char>(returnValue);
             }
@@ -354,8 +373,8 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return /*stoll(testCase.paramValues[0].view->getEntryValue()) == stoll(testCase.returnValue.view->getSubViews()[5]->getEntryValue())
-                         && */stoll(testCase.paramValues[1].view->getEntryValue()) == stoll(testCase.returnValue.view->getSubViews()[0]->getEntryValue());
+                  return /*stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) == stoll(testCase.returnValue.view->getSubViews()[5]->getEntryValue(nullptr))
+                         && */stoll(testCase.paramValues[1].view->getEntryValue(nullptr)) == stoll(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr));
                 }
                 }),
             "return_long_long_array");
@@ -370,11 +389,11 @@ namespace {
             testGen.tests.at(pointer_parameters_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.paramValues[2].view->getEntryValue()) + 7
-                        == stoi(testCase.returnValue.view->getEntryValue())
-                        && stoi(testCase.paramPostValues[0].view->getSubViews()[1]->getEntryValue())
+                    return stoi(testCase.paramValues[2].view->getEntryValue(nullptr)) + 7
+                        == stoi(testCase.returnValue.view->getEntryValue(nullptr))
+                        && stoi(testCase.paramPostValues[0].view->getSubViews()[1]->getEntryValue(nullptr))
                         == 3
-                        && stoi(testCase.paramPostValues[1].view->getEntryValue())
+                        && stoi(testCase.paramPostValues[1].view->getEntryValue(nullptr))
                         == 4;
                 }
                 }),
@@ -391,12 +410,12 @@ namespace {
                 testGen.tests.at(complex_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[&alphabet] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.returnValue.view->getEntryValue()) == 1 &&
-                                testCase.paramValues[0].view->getEntryValue().find(alphabet) != std::string::npos;
+                            return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1 &&
+                                testCase.paramValues[0].view->getEntryValue(nullptr).find(alphabet) != std::string::npos;
                         },
                          [&alphabet] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.returnValue.view->getEntryValue()) == 0 &&
-                                 testCase.paramValues[0].view->getEntryValue().find(alphabet) == std::string::npos;
+                             return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0 &&
+                                 testCase.paramValues[0].view->getEntryValue(nullptr).find(alphabet) == std::string::npos;
                          }
                         }),
                 "struct_has_alphabet");
@@ -411,12 +430,12 @@ namespace {
                 testGen.tests.at(complex_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoll(testCase.paramValues[0].view->getEntryValue()) >= 0 &&
-                                "{1, {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'}}" == testCase.returnValue.view->getEntryValue();
+                            return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) >= 0 &&
+                                "{1, {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'}}" == testCase.returnValue.view->getEntryValue(nullptr);
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoll(testCase.paramValues[0].view->getEntryValue()) < 0 &&
-                                "{-1, {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'}}" == testCase.returnValue.view->getEntryValue();
+                            return stoll(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 &&
+                                "{-1, {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'}}" == testCase.returnValue.view->getEntryValue(nullptr);
                          }
                         }),
                 "alphabet");
@@ -433,9 +452,9 @@ namespace {
                 {[] (const tests::Tests::MethodTestCase& testCase) {
                     std::string expectedString = StringUtils::stringFormat("{%s, {%s, %s}, 0}",
                                                                       PrinterUtils::C_NULL, PrinterUtils::C_NULL, PrinterUtils::C_NULL);
-                  return testCase.returnValue.view->getEntryValue() ==  expectedString &&
-                        testCase.paramValues[0].view->getEntryValue() == expectedString &&
-                        testCase.globalPostValues[0].view->getEntryValue() == expectedString;
+                  return testCase.returnValue.view->getEntryValue(nullptr) ==  expectedString &&
+                        testCase.paramValues[0].view->getEntryValue(nullptr) == expectedString &&
+                        testCase.globalPostValues[0].view->getEntryValue(nullptr) == expectedString;
                 }
                 }),
             "check_double_pointer");
@@ -450,20 +469,20 @@ namespace {
                 testGen.tests.at(types_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "false"
-                                && testCase.paramValues[1].view->getEntryValue() == "false" && testCase.returnValue.view->getEntryValue() == "4";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "false"
+                                && testCase.paramValues[1].view->getEntryValue(nullptr) == "false" && testCase.returnValue.view->getEntryValue(nullptr) == "4";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "false"
-                                && testCase.paramValues[1].view->getEntryValue() == "true" && testCase.returnValue.view->getEntryValue() == "3";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "false"
+                                && testCase.paramValues[1].view->getEntryValue(nullptr) == "true" && testCase.returnValue.view->getEntryValue(nullptr) == "3";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "true"
-                                && testCase.paramValues[1].view->getEntryValue() == "false" && testCase.returnValue.view->getEntryValue() == "2";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "true"
+                                && testCase.paramValues[1].view->getEntryValue(nullptr) == "false" && testCase.returnValue.view->getEntryValue(nullptr) == "2";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "true"
-                                && testCase.paramValues[1].view->getEntryValue() == "true" && testCase.returnValue.view->getEntryValue() == "1";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "true"
+                                && testCase.paramValues[1].view->getEntryValue(nullptr) == "true" && testCase.returnValue.view->getEntryValue(nullptr) == "1";
                         }
                         }),
                 "fun_that_accept_bools");
@@ -478,10 +497,10 @@ namespace {
                 testGen.tests.at(types_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) > 0 && testCase.returnValue.view->getEntryValue() == "true";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0 && testCase.returnValue.view->getEntryValue(nullptr) == "true";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) <= 0 && testCase.returnValue.view->getEntryValue() == "false";
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) <= 0 && testCase.returnValue.view->getEntryValue(nullptr) == "false";
                          }
                         }),
                 "is_positive");
@@ -496,13 +515,13 @@ namespace {
                 testGen.tests.at(enums_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "NEGATIVE" && stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "NEGATIVE" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "ZERO" && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "ZERO" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "POSITIVE" && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "POSITIVE" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                          }
                         }
                 )
@@ -518,7 +537,7 @@ namespace {
             testGen.tests.at(pointer_parameters_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return testCase.paramValues[0].view->getEntryValue() == "0" && stoll(testCase.returnValue.view->getEntryValue()) == 0;
+                  return testCase.paramValues[0].view->getEntryValue(nullptr) == "0" && stoll(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 }
                 }),
             "void_pointer_int_usage");
@@ -533,16 +552,16 @@ namespace {
                 testGen.tests.at(enums_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue().find("NEGATIVE") != std::string::npos
-                                && stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr).find("NEGATIVE") != std::string::npos
+                                && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                           return testCase.paramValues[0].view->getEntryValue().find("POSITIVE") != std::string::npos
-                                && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                           return testCase.paramValues[0].view->getEntryValue(nullptr).find("POSITIVE") != std::string::npos
+                                && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue().find("ZERO") != std::string::npos
-                                && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr).find("ZERO") != std::string::npos
+                                && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                          }
                         }
                 )
@@ -576,13 +595,13 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
 
-                            return testCase.paramValues[0].view->getEntryValue() == "{ZERO}" && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "{ZERO}" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "{POSITIVE}" && stoi(testCase.returnValue.view->getEntryValue()) > 0;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "{POSITIVE}" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) > 0;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "{NEGATIVE}" && stoi(testCase.returnValue.view->getEntryValue()) < 0;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "{NEGATIVE}" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) < 0;
                          }
                         }
                 )
@@ -598,13 +617,13 @@ namespace {
                 testGen.tests.at(enums_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "NEGATIVE" && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "NEGATIVE" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "ZERO" && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "ZERO" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                          },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "POSITIVE" && stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "POSITIVE" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                          }
                         }
                 ),
@@ -622,17 +641,17 @@ namespace {
             testGen.tests.at(enums_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 { [](const tests::Tests::MethodTestCase &testCase) {
-                     return testCase.paramValues[0].view->getEntryValue() ==
+                     return testCase.paramValues[0].view->getEntryValue(nullptr) ==
                                 "{EnumWithinRecord::CLOSED}" &&
-                            stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                            stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                  },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                      return testCase.paramValues[0].view->getEntryValue() ==
+                      return testCase.paramValues[0].view->getEntryValue(nullptr) ==
                                  "{EnumWithinRecord::OPEN}" &&
-                             stoi(testCase.returnValue.view->getEntryValue()) == +1;
+                             stoi(testCase.returnValue.view->getEntryValue(nullptr)) == +1;
                   },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                   } }),
             "enumWithinRecord"
         );
@@ -647,19 +666,19 @@ namespace {
                 testGen.tests.at(typedefs_1_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            auto strParam = testCase.paramValues[0].view->getEntryValue();
+                            auto strParam = testCase.paramValues[0].view->getEntryValue(nullptr);
                             return stoi(strParam.substr(1, strParam.size() - 2)) > 0
-                            && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                            && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             auto strParam = testCase.paramValues[0].view->getEntryValue();
+                             auto strParam = testCase.paramValues[0].view->getEntryValue(nullptr);
                              return stoi(strParam.substr(1, strParam.size() - 2)) == 0
-                             && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                             && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             auto strParam = testCase.paramValues[0].view->getEntryValue();
+                             auto strParam = testCase.paramValues[0].view->getEntryValue(nullptr);
                              return stoi(strParam.substr(1, strParam.size() - 2)) < 0
-                             && stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                             && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                          }
                         }),
                 "sign_of_typedef_struct");
@@ -674,12 +693,12 @@ namespace {
                 testGen.tests.at(typedefs_1_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) < stoi(testCase.paramValues[1].view->getEntryValue())
-                            && stoi(testCase.returnValue.view->getEntryValue()) == stoi(testCase.paramValues[0].view->getEntryValue());
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoi(testCase.paramValues[1].view->getEntryValue(nullptr))
+                            && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) >= stoi(testCase.paramValues[1].view->getEntryValue())
-                             && stoi(testCase.returnValue.view->getEntryValue()) == stoi(testCase.paramValues[1].view->getEntryValue());
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoi(testCase.paramValues[1].view->getEntryValue(nullptr))
+                             && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == stoi(testCase.paramValues[1].view->getEntryValue(nullptr));
                          }
                         }),
                 "min_size_t");
@@ -695,12 +714,12 @@ namespace {
                 testGen.tests.at(typedefs_1_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) < stoi(testCase.paramValues[1].view->getEntryValue())
-                            && stoi(testCase.returnValue.view->getEntryValue()) == stoi(testCase.paramValues[0].view->getEntryValue());
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoi(testCase.paramValues[1].view->getEntryValue(nullptr))
+                            && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) >= stoi(testCase.paramValues[1].view->getEntryValue())
-                             && stoi(testCase.returnValue.view->getEntryValue()) == stoi(testCase.paramValues[1].view->getEntryValue());
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoi(testCase.paramValues[1].view->getEntryValue(nullptr))
+                             && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == stoi(testCase.paramValues[1].view->getEntryValue(nullptr));
                          }
                         }),
                 "min_size_t_alias");
@@ -715,13 +734,13 @@ namespace {
                 testGen.tests.at(typedefs_2_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "NEG1" && stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "NEG1" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "ZER1" && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "ZER1" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() == "POS1" && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "POS1" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                          }
                         }
                 )
@@ -737,13 +756,13 @@ namespace {
                 testGen.tests.at(typedefs_2_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 && testCase.returnValue.view->getEntryValue() == "NEG2";
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 && testCase.returnValue.view->getEntryValue(nullptr) == "NEG2";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 && testCase.returnValue.view->getEntryValue() == "ZER2";
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 && testCase.returnValue.view->getEntryValue(nullptr) == "ZER2";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) > 0 && testCase.returnValue.view->getEntryValue() == "POS2";
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0 && testCase.returnValue.view->getEntryValue(nullptr) == "POS2";
                          }
                         }
                 )
@@ -759,16 +778,16 @@ namespace {
                 testGen.tests.at(packed_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue()) > 0
-                                && testCase.returnValue.view->getEntryValue() == "1";
+                            return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue(nullptr)) > 0
+                                && testCase.returnValue.view->getEntryValue(nullptr) == "1";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue()) < 0
-                                && testCase.returnValue.view->getEntryValue() == "-1";
+                             return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue(nullptr)) < 0
+                                && testCase.returnValue.view->getEntryValue(nullptr) == "-1";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue()) == 0
-                                && testCase.returnValue.view->getEntryValue() == "0";
+                             return stoi(testCase.paramValues[0].view->getSubViews().back()->getEntryValue(nullptr)) == 0
+                                && testCase.returnValue.view->getEntryValue(nullptr) == "0";
                          }
                         }
                 )
@@ -784,18 +803,18 @@ namespace {
                 testGen.tests.at(packed_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '1');
+                            return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '1');
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
 
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '2');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '2');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
 
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(),'3');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr),'3');
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(),'4');
+                             return testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr),'4');
                          }
                         }
                 )
@@ -812,10 +831,10 @@ namespace {
                 testGen.tests.at(constants_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "4294967295U" && testCase.returnValue.view->getEntryValue() == "true";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "4294967295U" && testCase.returnValue.view->getEntryValue(nullptr) == "true";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() != "4294967295U" && testCase.returnValue.view->getEntryValue() == "false";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) != "4294967295U" && testCase.returnValue.view->getEntryValue(nullptr) == "false";
                          }
                         }
                 ),
@@ -833,10 +852,10 @@ namespace {
                 testGen.tests.at(constants_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "9223372036854775807LL" && testCase.returnValue.view->getEntryValue() == "true";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "9223372036854775807LL" && testCase.returnValue.view->getEntryValue(nullptr) == "true";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() != "9223372036854775807LL" && testCase.returnValue.view->getEntryValue() == "false";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) != "9223372036854775807LL" && testCase.returnValue.view->getEntryValue(nullptr) == "false";
                          }
                         }
                 ),
@@ -854,10 +873,10 @@ namespace {
                 testGen.tests.at(constants_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "(-9223372036854775807LL - 1)" && testCase.returnValue.view->getEntryValue() == "true";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "(-9223372036854775807LL - 1)" && testCase.returnValue.view->getEntryValue(nullptr) == "true";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() != "(-9223372036854775807LL - 1)" && testCase.returnValue.view->getEntryValue() == "false";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) != "(-9223372036854775807LL - 1)" && testCase.returnValue.view->getEntryValue(nullptr) == "false";
                          }
                         }
                 ),
@@ -875,10 +894,10 @@ namespace {
                 testGen.tests.at(constants_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "18446744073709551615ULL" && testCase.returnValue.view->getEntryValue() == "true";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "18446744073709551615ULL" && testCase.returnValue.view->getEntryValue(nullptr) == "true";
                         },
                          [](const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.paramValues[0].view->getEntryValue() != "18446744073709551615ULL" && testCase.returnValue.view->getEntryValue() == "false";
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) != "18446744073709551615ULL" && testCase.returnValue.view->getEntryValue(nullptr) == "false";
                          }
                         }
                 ),
@@ -895,17 +914,17 @@ namespace {
                 testGen.tests.at(packed_structs_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return testCase.returnValue.view->getEntryValue() == "0";
+                            return testCase.returnValue.view->getEntryValue(nullptr) == "0";
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
 
-                             return testCase.returnValue.view->getEntryValue() == "5";
+                             return testCase.returnValue.view->getEntryValue(nullptr) == "5";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.returnValue.view->getEntryValue() == "-1";
+                             return testCase.returnValue.view->getEntryValue(nullptr) == "-1";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return testCase.returnValue.view->getEntryValue() == testCase.paramValues[0].view->getSubViews()[3]->getEntryValue();
+                             return testCase.returnValue.view->getEntryValue(nullptr) == testCase.paramValues[0].view->getSubViews()[3]->getEntryValue(nullptr);
                          }
                         }
                 )
@@ -922,13 +941,13 @@ namespace {
                 testGen.tests.at(void_functions_c).methods.begin().value().testCases,
                     std::vector<TestCasePredicate>(
                             {[] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.paramValues[0].view->getEntryValue()) < 0;
+                                return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0;
                             },
                              [] (const tests::Tests::MethodTestCase& testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) > 0;
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0;
                              },
                              [] (const tests::Tests::MethodTestCase& testCase) {
-                                 return stoi(testCase.paramValues[0].view->getEntryValue()) == 0;
+                                 return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0;
                              }
                             })
                 );
@@ -943,13 +962,13 @@ namespace {
                 testGen.tests.at(void_functions_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue()) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue()) < 0;
+                            return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue(nullptr)) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue(nullptr)) < 0;
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue()) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue()) > 0;
+                             return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue(nullptr)) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue(nullptr)) > 0;
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue()) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue()) == 0;
+                             return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue(nullptr)) * stoi(testCase.paramValues[1].view->getSubViews()[0]->getEntryValue(nullptr)) == 0;
                          }
                         })
         );
@@ -978,7 +997,7 @@ namespace {
             testGen.tests.at(void_functions_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 6;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 6;
                 }
                 })
         );
@@ -993,10 +1012,10 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'a');
+                    return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'a');
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) != 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'b');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'b');
                  }
                 })
         );
@@ -1011,10 +1030,10 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'a');
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'a');
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) != 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), 'b');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), 'b');
                  }
                 })
         );
@@ -1029,12 +1048,12 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) < stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                      stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) < stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue());
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                      stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) < stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue(nullptr));
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) >= stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                          stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) >= stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue());
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                          stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) >= stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue(nullptr));
                  }
                 })
         );
@@ -1049,7 +1068,7 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == 5;
+                  return stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == 5;
                 }
                 })
         );
@@ -1070,13 +1089,13 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return testCase.returnValue.view->getEntryValue() == "5";
+                  return testCase.returnValue.view->getEntryValue(nullptr) == "5";
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return testCase.returnValue.view->getEntryValue() == "9";
+                   return testCase.returnValue.view->getEntryValue(nullptr) == "9";
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                    return testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL;
+                    return testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL;
                   }
                 })
         );
@@ -1091,10 +1110,10 @@ namespace {
             testGen.tests.at(pointer_return_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL;
+                  return testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return testCase.returnValue.view->getEntryValue() == PrinterUtils::C_NULL;
+                   return testCase.returnValue.view->getEntryValue(nullptr) == PrinterUtils::C_NULL;
                  }
                 })
         );
@@ -1109,10 +1128,10 @@ namespace {
             testGen.tests.at(qualifiers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return testCase.paramValues[0].view->getEntryValue() == "\"hello\"" && stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                  return testCase.paramValues[0].view->getEntryValue(nullptr) == "\"hello\"" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return testCase.paramValues[0].view->getEntryValue() !=  "\"hello\"" && stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                   return testCase.paramValues[0].view->getEntryValue(nullptr) !=  "\"hello\"" && stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                  }
                 })
         );
@@ -1127,13 +1146,13 @@ namespace {
             testGen.tests.at(qualifiers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '-');
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '-');
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) > 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '1');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '1');
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '0');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '0');
                  }
                 })
         );
@@ -1148,13 +1167,13 @@ namespace {
             testGen.tests.at(qualifiers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '-');
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '-');
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) > 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '1');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '1');
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(), '0');
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 && testUtils::cmpChars(testCase.returnValue.view->getEntryValue(nullptr), '0');
                  }
                 })
         );
@@ -1169,14 +1188,14 @@ namespace {
             testGen.tests.at(qualifiers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) < stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                    stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == stoi(testCase.paramValues[0].view->getEntryValue()) &&
-                      stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue()) == stoi(testCase.paramValues[1].view->getEntryValue());
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                    stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) &&
+                      stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue(nullptr)) == stoi(testCase.paramValues[1].view->getEntryValue(nullptr));
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) >= stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                          stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                          stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue()) == stoi(testCase.paramValues[0].view->getEntryValue());
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >= stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                          stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                          stoi(testCase.returnValue.view->getSubViews()[1]->getEntryValue(nullptr)) == stoi(testCase.paramValues[0].view->getEntryValue(nullptr));
                  }
                 })
         );
@@ -1190,12 +1209,12 @@ namespace {
             testGen.tests.at(structs_with_pointers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue()) > 0 &&
-                            stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                  return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue(nullptr)) > 0 &&
+                            stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue()) <= 0 &&
-                          stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                   return stoi(testCase.paramValues[0].view->getSubViews()[0]->getEntryValue(nullptr)) <= 0 &&
+                          stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                  }
                 })
         );
@@ -1217,13 +1236,13 @@ namespace {
             testGen.tests.at(structs_with_pointers_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[](const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                        return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                  },
                   [](const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                        return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                   },
                   [](const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == -1; }
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1; }
                 })
         );
     }
@@ -1318,13 +1337,13 @@ namespace {
             testGen.tests.at(functions_as_params_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 8;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 8;
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                  }
                 })
         );
@@ -1338,10 +1357,10 @@ namespace {
             testGen.tests.at(functions_as_params_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return testCase.returnValue.view->getEntryValue() == "'\\0'";
+                  return testCase.returnValue.view->getEntryValue(nullptr) == "'\\0'";
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return testCase.returnValue.view->getEntryValue() == "'\\0'";
+                   return testCase.returnValue.view->getEntryValue(nullptr) == "'\\0'";
                  }
                 })
         );
@@ -1355,13 +1374,13 @@ namespace {
             testGen.tests.at(functions_as_params_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 6;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 6;
                 },
                 [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 }
                 })
         );
@@ -1375,13 +1394,13 @@ namespace {
             testGen.tests.at(functions_as_params_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 12;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 12;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                  }
                 })
         );
@@ -1406,10 +1425,10 @@ namespace {
             testGen.tests.at(functions_as_params_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                  }
                 })
         );
@@ -1472,19 +1491,19 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[](const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 1 &&
-                         testCase.paramValues.front().view->getEntryValue() ==
-                         testCase.paramPostValues.front().view->getEntryValue();
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1 &&
+                         testCase.paramValues.front().view->getEntryValue(nullptr) ==
+                         testCase.paramPostValues.front().view->getEntryValue(nullptr);
                 },
                  [](const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 0 &&
-                          testCase.paramValues.front().view->getEntryValue() ==
-                          testCase.paramPostValues.front().view->getEntryValue();
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0 &&
+                          testCase.paramValues.front().view->getEntryValue(nullptr) ==
+                          testCase.paramPostValues.front().view->getEntryValue(nullptr);
                  },
                  [](const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == -1 &&
-                          testCase.paramValues.front().view->getEntryValue() ==
-                          testCase.paramPostValues.front().view->getEntryValue(); }
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1 &&
+                          testCase.paramValues.front().view->getEntryValue(nullptr) ==
+                          testCase.paramPostValues.front().view->getEntryValue(nullptr); }
                 })
         );
     }
@@ -1505,13 +1524,13 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[](const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                  [](const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                  },
                  [](const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == -1; }
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1; }
                 })
         );
     }
@@ -1524,16 +1543,16 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 3;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 3;
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.returnValue.view->getEntryValue()) == 4;
+                   return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 4;
                  }
                 })
         );
@@ -1547,16 +1566,16 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 {[] (const tests::Tests::MethodTestCase& testCase) {
-                  return stoi(testCase.paramValues[0].view->getEntryValue()) > 0 &&
-                      testCase.returnValue.view->getEntryValue() == "{{{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}}}";
+                  return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) > 0 &&
+                      testCase.returnValue.view->getEntryValue(nullptr) == "{{{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}}}";
                 },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) < 0 &&
-                       testCase.returnValue.view->getEntryValue() == "{{{-1, -2, -3, -4, -5}, {-1, -2, -3, -4, -5}}}";
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) < 0 &&
+                       testCase.returnValue.view->getEntryValue(nullptr) == "{{{-1, -2, -3, -4, -5}, {-1, -2, -3, -4, -5}}}";
                  },
                  [] (const tests::Tests::MethodTestCase& testCase) {
-                   return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 &&
-                          testCase.returnValue.view->getEntryValue() == "{{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}}";
+                   return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 &&
+                          testCase.returnValue.view->getEntryValue(nullptr) == "{{{0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}}}";
                  }
                 })
         );
@@ -1570,13 +1589,13 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 { [](const tests::Tests::MethodTestCase &testCase) {
-                     return stoi(testCase.returnValue.view->getEntryValue()) < 0;
+                     return stoi(testCase.returnValue.view->getEntryValue(nullptr)) < 0;
                  },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                   },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) > 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) > 0;
                   } }));
     }
 
@@ -1588,13 +1607,13 @@ namespace {
             testGen.tests.at(multi_arrays_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                 { [](const tests::Tests::MethodTestCase &testCase) {
-                  return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                  return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) > 0;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) > 0;
                   },
                   [](const tests::Tests::MethodTestCase &testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                   } }));
     }
 
@@ -1608,7 +1627,7 @@ namespace {
                 testGen.tests.at(floats_special_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase &testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "NAN";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "NAN";
                         }}));
     }
 
@@ -1621,7 +1640,7 @@ namespace {
                 testGen.tests.at(floats_special_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase &testCase) {
-                            return testCase.paramValues[0].view->getEntryValue() == "NAN";
+                            return testCase.paramValues[0].view->getEntryValue(nullptr) == "NAN";
                         }}));
     }
 
@@ -1635,7 +1654,7 @@ namespace {
             testGen.tests.at(floats_special_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>(
                     { [](const tests::Tests::MethodTestCase &testCase) {
-                        return testCase.paramValues[0].view->getEntryValue() == "INFINITY";
+                        return testCase.paramValues[0].view->getEntryValue(nullptr) == "INFINITY";
                     } }));
     }
 
@@ -1687,17 +1706,17 @@ namespace {
                 testGen.tests.at(struct_with_union_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) != 0 &&
-                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) != 0 &&
+                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                             "{from_bytes<StructWithUnion::InnerUnion>({17, 0, 0, 0}), "
                                                             "{from_bytes<StructWithUnion::InnerStructWithUnion::Inner2Union>({48,")
-                                    && StringUtils::endsWith(testCase.returnValue.view->getEntryValue(), "})}, -108}");
+                                    && StringUtils::endsWith(testCase.returnValue.view->getEntryValue(nullptr), "})}, -108}");
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) == 0 &&
-                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) == 0 &&
+                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                             "{from_bytes<StructWithUnion::InnerUnion>({97,")
-                                    && StringUtils::endsWith(testCase.returnValue.view->getEntryValue(),
+                                    && StringUtils::endsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                              "}), {from_bytes<StructWithUnion::InnerStructWithUnion::Inner2Union>({101, 0, 0, 0})}, 155}");
                          }
                         })
@@ -1713,23 +1732,23 @@ namespace {
                 testGen.tests.at(struct_with_union_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) +
-                                   stoi(testCase.paramValues[1].view->getEntryValue()) < 0 &&
-                                   StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) +
+                                   stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) < 0 &&
+                                   StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                            "{from_bytes<StructWithUnionInUnion::Union1>({98,");
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) +
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) >= 0 &&
-                                    stoi(testCase.paramValues[0].view->getEntryValue()) +
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) <= 16 &&
-                                    testCase.returnValue.view->getEntryValue() ==
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) +
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) >= 0 &&
+                                    stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) +
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) <= 16 &&
+                                    testCase.returnValue.view->getEntryValue(nullptr) ==
                                             "{from_bytes<StructWithUnionInUnion::Union1>({-113, -62, -11, 40, 92, -113, -10, 63})}";
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) +
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) > 16 &&
-                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) +
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) > 16 &&
+                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                             "{from_bytes<StructWithUnionInUnion::Union1>({-5, -1, -1, -1,");
                          }
                         })
@@ -1745,23 +1764,23 @@ namespace {
                 testGen.tests.at(struct_with_union_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>(
                         {[] (const tests::Tests::MethodTestCase& testCase) {
-                            return stoi(testCase.paramValues[0].view->getEntryValue()) <
-                                   stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                   StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                            return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) <
+                                   stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                   StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                            "{from_bytes<StructWithStructInUnion::DeepUnion>({-103, 0, 0, 0, 0, 0, 0, 0,");
                         },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) ==
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) ==
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                             "{from_bytes<StructWithStructInUnion::DeepUnion>({107,") &&
-                                    StringUtils::endsWith(testCase.returnValue.view->getEntryValue(),
+                                    StringUtils::endsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                           "-102, 8, 27, -98, 94, 41, -16, 63})}");
                          },
                          [] (const tests::Tests::MethodTestCase& testCase) {
-                             return stoi(testCase.paramValues[0].view->getEntryValue()) >
-                                    stoi(testCase.paramValues[1].view->getEntryValue()) &&
-                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(),
+                             return stoi(testCase.paramValues[0].view->getEntryValue(nullptr)) >
+                                    stoi(testCase.paramValues[1].view->getEntryValue(nullptr)) &&
+                                    StringUtils::startsWith(testCase.returnValue.view->getEntryValue(nullptr),
                                                             "{from_bytes<StructWithStructInUnion::DeepUnion>({0, 0, 0, 0, 0, 0, 0, 0,");
                          }
                         })
@@ -1778,16 +1797,16 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                                 },
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                                 },
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == 3;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 3;
                                 },
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                             }
                         })
         );
@@ -1803,13 +1822,13 @@ namespace {
                     std::vector<TestCasePredicate>(
                         {
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                                 },
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                                 },
                             [] (const tests::Tests::MethodTestCase& testCase) {
-                                return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                                return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                             }
                         })
         );
@@ -1825,13 +1844,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     }
                 })
         );
@@ -1847,13 +1866,13 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                                 }
                         })
         );
@@ -1869,34 +1888,34 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 3;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 3;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 4;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 4;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 5;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 5;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 6;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 6;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == -2;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -2;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == -3;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -3;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 17;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 17;
                                 }
                         })
         );
@@ -1912,10 +1931,10 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                 },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) > -1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) > -1;
                 }
             })
         );
@@ -1931,13 +1950,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                 },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                 },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                    return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                 }
             })
         );
@@ -1953,13 +1972,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                     }
                 })
         );
@@ -1975,13 +1994,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                     }
                 })
         );
@@ -1997,13 +2016,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                     }
                 })
         );
@@ -2027,10 +2046,10 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     }
                 })
         );
@@ -2046,10 +2065,10 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                                 },
                                 [] (const tests::Tests::MethodTestCase& testCase) {
-                                    return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                                    return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                                 }
                         })
         );
@@ -2132,7 +2151,7 @@ namespace {
             testGen.tests.at(types_3_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
               EXPECT_TRUE(testCase.globalPostValues.empty());
-              return testCase.returnValue.view->getEntryValue() == "-1";
+              return testCase.returnValue.view->getEntryValue(nullptr) == "-1";
             } }),
             "check_option");
     }
@@ -2234,10 +2253,10 @@ namespace {
               testGen.tests.at(different_parameters_cpp).methods.begin().value().testCases,
               std::vector<TestCasePredicate>(
                       {[] (const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.paramPostValues[0].view->getEntryValue()) == stoi(testCase.returnValue.view->getEntryValue());
+                        return stoi(testCase.paramPostValues[0].view->getEntryValue(nullptr)) == stoi(testCase.returnValue.view->getEntryValue(nullptr));
                        },
                        [] (const tests::Tests::MethodTestCase& testCase) {
-                         return stoi(testCase.paramPostValues[0].view->getEntryValue()) == stoi(testCase.returnValue.view->getEntryValue());
+                         return stoi(testCase.paramPostValues[0].view->getEntryValue(nullptr)) == stoi(testCase.returnValue.view->getEntryValue(nullptr));
                        }
                       }),
               "pointer_parameter_cpp");
@@ -2255,13 +2274,13 @@ namespace {
                 std::vector<TestCasePredicate>(
                         {[](const tests::Tests::MethodTestCase &testCase) {
                             return stoi(
-                                    testCase.paramPostValues[0].view->getSubViews().front()->getSubViews().front()->getEntryValue()) ==
-                                   stoi(testCase.returnValue.view->getEntryValue());
+                                    testCase.paramPostValues[0].view->getSubViews().front()->getSubViews().front()->getEntryValue(nullptr)) ==
+                                   stoi(testCase.returnValue.view->getEntryValue(nullptr));
                         },
                          [](const tests::Tests::MethodTestCase &testCase) {
                              return stoi(
-                                     testCase.paramPostValues[0].view->getSubViews().front()->getSubViews().front()->getEntryValue()) ==
-                                    stoi(testCase.returnValue.view->getEntryValue());
+                                     testCase.paramPostValues[0].view->getSubViews().front()->getSubViews().front()->getEntryValue(nullptr)) ==
+                                    stoi(testCase.returnValue.view->getEntryValue(nullptr));
                          }
                         }),
                 "Double_pointer_parameter_cpp");
@@ -2278,10 +2297,10 @@ namespace {
               testGen.tests.at(different_parameters_cpp).methods.begin().value().testCases,
               std::vector<TestCasePredicate>(
                       {[] (const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.paramPostValues[0].view->getEntryValue()) == stoi(testCase.returnValue.view->getEntryValue());
+                        return stoi(testCase.paramPostValues[0].view->getEntryValue(nullptr)) == stoi(testCase.returnValue.view->getEntryValue(nullptr));
                         },
                        [] (const tests::Tests::MethodTestCase& testCase) {
-                         return stoi(testCase.paramPostValues[0].view->getEntryValue()) == stoi(testCase.returnValue.view->getEntryValue());
+                         return stoi(testCase.paramPostValues[0].view->getEntryValue(nullptr)) == stoi(testCase.returnValue.view->getEntryValue(nullptr));
                         }
                       }),
               "lvalue_parameter");
@@ -2379,6 +2398,12 @@ namespace {
         auto [testGen, status] = createTestForFunction(simple_class_cpp, 38);
 
         ASSERT_TRUE(status.ok()) << status.error_message();
+        printer::TestsPrinter testsPrinter(nullptr, utbot::Language::CXX);
+        const auto &tests = testGen.tests.at(simple_class_cpp)
+                                .methods.begin().value().testCases.begin();
+        ASSERT_EQ("{"
+                  "\n    /*.x = */-1,"
+                  "\n    /*.y = */2}", tests[0].paramValues[0].view->getEntryValue(&testsPrinter));
 
         testUtils::checkMinNumberOfTests(testGen.tests.at(simple_class_cpp).methods.begin().value().testCases, 5);
 
@@ -2386,20 +2411,20 @@ namespace {
               testGen.tests.at(simple_class_cpp).methods.begin().value().testCases,
               std::vector<TestCasePredicate>(
                       {[] (const tests::Tests::MethodTestCase& testCase) {
-                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue() == "0" &&
-                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue() == "0";
+                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr) == "0" &&
+                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr) == "0";
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue() == "0" &&
-                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue() == "0";
+                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr) == "0" &&
+                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr) == "0";
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue() == "0" &&
-                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue() == "0";
+                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr) == "0" &&
+                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr) == "0";
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue() == "0" &&
-                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue() == "0";
+                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr) == "0" &&
+                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr) == "0";
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue() == "0" &&
-                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue() == "0";
+                        return testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr) == "0" &&
+                               testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr) == "0";
                       }
                       }),
               "change_class_by_ref_cpp");
@@ -2416,20 +2441,20 @@ namespace {
               testGen.tests.at(simple_class_cpp).methods.begin().value().testCases,
               std::vector<TestCasePredicate>(
                       {[] (const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[1]->getEntryValue()));
+                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[1]->getEntryValue(nullptr)));
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue()));
+                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue(nullptr)));
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
-                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue()));
+                        return stoi(testCase.paramPostValues.front().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.paramPostValues.front().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.paramValues.front().view->getSubViews()[0]->getEntryValue(nullptr)));
                       }
                       }),
               "change_class_by_ref_2_cpp");
@@ -2447,22 +2472,22 @@ namespace {
               std::vector<TestCasePredicate>(
                       {[] (const tests::Tests::MethodTestCase& testCase) {
                         return testCase.classPostValues.has_value() &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[1]->getEntryValue()));
+                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[1]->getEntryValue(nullptr)));
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
                         return testCase.classPostValues.has_value() &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue()));
+                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue(nullptr)));
                       }, [] (const tests::Tests::MethodTestCase& testCase) {
                         return testCase.classPostValues.has_value() &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue())) &&
-                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue())
-                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue()));
+                               stoi(testCase.classPostValues.value().view->getSubViews()[0]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue(nullptr))) &&
+                               stoi(testCase.classPostValues.value().view->getSubViews()[1]->getEntryValue(nullptr))
+                                   == abs(stoi(testCase.classPreValues.value().view->getSubViews()[0]->getEntryValue(nullptr)));
                       }
                       }),
               "change_class_by_method_cpp");
@@ -2477,13 +2502,13 @@ namespace {
                 testGen.tests.at(inner_unnamed_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
                     std::stringstream ss;
-                    EXPECT_EQ(testCase.paramValues.front().view->getEntryValue().size(), 3);
+                    EXPECT_EQ(testCase.paramValues.front().view->getEntryValue(nullptr).size(), 3);
                     ss << "from_bytes<StructWithUnnamedUnion>({"
-                       << int(testCase.paramValues.front().view->getEntryValue()[1])
+                       << int(testCase.paramValues.front().view->getEntryValue(nullptr)[1])
                        << ", 0, 0, 0, "
-                       << int(testCase.paramValues.front().view->getEntryValue()[1])
+                       << int(testCase.paramValues.front().view->getEntryValue(nullptr)[1])
                        << ", 0, 0, 0})";
-                    return testCase.returnValue.view->getEntryValue() == ss.str();
+                    return testCase.returnValue.view->getEntryValue(nullptr) == ss.str();
                 }}));
     }
 
@@ -2496,14 +2521,14 @@ namespace {
                 testGen.tests.at(inner_unnamed_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
                     return "from_bytes<StructWithUnnamedUnion>({0, 0, 0, 0, 0, 0, 0, 0})" ==
-                           testCase.paramValues.front().view->getEntryValue() &&
+                           testCase.paramValues.front().view->getEntryValue(nullptr) &&
                            "from_bytes<StructWithUnnamedUnion>({42, 0, 0, 0, 42, 0, 0, 0})" ==
-                           testCase.returnValue.view->getEntryValue();
+                           testCase.returnValue.view->getEntryValue(nullptr);
                 }, [](const tests::Tests::MethodTestCase &testCase) {
                     return "from_bytes<StructWithUnnamedUnion>({0, 0, 0, 0, 0, 0, 0, 0})" !=
-                           testCase.paramValues.front().view->getEntryValue() &&
+                           testCase.paramValues.front().view->getEntryValue(nullptr) &&
                            "from_bytes<StructWithUnnamedUnion>({24, 0, 0, 0, 24, 0, 0, 0})" ==
-                           testCase.returnValue.view->getEntryValue();
+                           testCase.returnValue.view->getEntryValue(nullptr);
 
                 }}));
     }
@@ -2517,13 +2542,13 @@ namespace {
                 testGen.tests.at(inner_unnamed_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
                     std::stringstream ss;
-                    EXPECT_EQ(testCase.paramValues.front().view->getEntryValue().size(), 3);
+                    EXPECT_EQ(testCase.paramValues.front().view->getEntryValue(nullptr).size(), 3);
                     ss << "from_bytes<UnionWithUnnamedStruct>({"
-                       << int(testCase.paramValues.front().view->getEntryValue()[1])
+                       << int(testCase.paramValues.front().view->getEntryValue(nullptr)[1])
                        << ", 0, 0, 0, "
-                       << int(testCase.paramValues.front().view->getEntryValue()[1])
+                       << int(testCase.paramValues.front().view->getEntryValue(nullptr)[1])
                        << ", 0, 0, 0})";
-                    return testCase.returnValue.view->getEntryValue() == ss.str();
+                    return testCase.returnValue.view->getEntryValue(nullptr) == ss.str();
                 }}));
     }
 
@@ -2537,14 +2562,14 @@ namespace {
                 testGen.tests.at(inner_unnamed_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
                     return "from_bytes<UnionWithUnnamedStruct>({0, 0, 0, 0, 0, 0, 0, 0})" ==
-                           testCase.paramValues.front().view->getEntryValue() &&
+                           testCase.paramValues.front().view->getEntryValue(nullptr) &&
                            "from_bytes<UnionWithUnnamedStruct>({42, 0, 0, 0, 42, 0, 0, 0})" ==
-                           testCase.returnValue.view->getEntryValue();
+                           testCase.returnValue.view->getEntryValue(nullptr);
                 }, [](const tests::Tests::MethodTestCase &testCase) {
                     return "from_bytes<UnionWithUnnamedStruct>({0, 0, 0, 0, 0, 0, 0, 0})" !=
-                           testCase.paramValues.front().view->getEntryValue() &&
+                           testCase.paramValues.front().view->getEntryValue(nullptr) &&
                            "from_bytes<UnionWithUnnamedStruct>({24, 0, 0, 0, 24, 0, 0, 0})" ==
-                           testCase.returnValue.view->getEntryValue();
+                           testCase.returnValue.view->getEntryValue(nullptr);
 
                 }}));
     }
@@ -2559,11 +2584,11 @@ namespace {
         checkTestCasePredicates(
                 testGen.tests.at(pointer_parameters_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
-                    return "{{0}, {0}}" == testCase.paramValues.front().view->getEntryValue() &&
-                           "42" == testCase.returnValue.view->getEntryValue();
+                    return "{{0}, {0}}" == testCase.paramValues.front().view->getEntryValue(nullptr) &&
+                           "42" == testCase.returnValue.view->getEntryValue(nullptr);
                 }, [](const tests::Tests::MethodTestCase &testCase) {
-                    return "{{0}, {0}}" != testCase.paramValues.front().view->getEntryValue() &&
-                           "24" == testCase.returnValue.view->getEntryValue();
+                    return "{{0}, {0}}" != testCase.paramValues.front().view->getEntryValue(nullptr) &&
+                           "24" == testCase.returnValue.view->getEntryValue(nullptr);
                 }
                                           }));
     }
@@ -2578,13 +2603,13 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     }
                 })
         );
@@ -2600,19 +2625,19 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 0;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 0;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 2;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 2;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 3;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 3;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == -1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == -1;
                     }
                 })
         );
@@ -2628,7 +2653,7 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return stoi(testCase.returnValue.view->getEntryValue()) == 1;
+                      return stoi(testCase.returnValue.view->getEntryValue(nullptr)) == 1;
                     }
                 })
         );
@@ -2644,16 +2669,16 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(), "from_bytes<uni::inner1::U>") &&
-                             stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == 5;
+                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(nullptr), "from_bytes<uni::inner1::U>") &&
+                             stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == 5;
                     },
                      [] (const tests::Tests::MethodTestCase& testCase) {
-                       return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(), "from_bytes<uni::inner1::U>") &&
-                              stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == -1;
+                       return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(nullptr), "from_bytes<uni::inner1::U>") &&
+                              stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == -1;
                      },
                      [] (const tests::Tests::MethodTestCase& testCase) {
-                       return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(), "from_bytes<uni::inner1::U>") &&
-                              stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue()) == 10;
+                       return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[2]->getEntryValue(nullptr), "from_bytes<uni::inner1::U>") &&
+                              stoi(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr)) == 10;
                      }
                 })
         );
@@ -2669,16 +2694,16 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(), "from_bytes<StructWithUnion::InnerUnion>") &&
-                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getSubViews()[0]->getEntryValue(),
+                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr), "from_bytes<StructWithUnion::InnerUnion>") &&
+                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getSubViews()[0]->getEntryValue(nullptr),
                                                        "from_bytes<StructWithUnion::InnerStructWithUnion::Inner2Union>") &&
-                               stoi(testCase.returnValue.view->getSubViews()[2]->getEntryValue()) == -108;
+                               stoi(testCase.returnValue.view->getSubViews()[2]->getEntryValue(nullptr)) == -108;
                     },
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(), "from_bytes<StructWithUnion::InnerUnion>") &&
-                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getSubViews()[0]->getEntryValue(),
+                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr), "from_bytes<StructWithUnion::InnerUnion>") &&
+                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getSubViews()[0]->getEntryValue(nullptr),
                                                      "from_bytes<StructWithUnion::InnerStructWithUnion::Inner2Union>") &&
-                             stoi(testCase.returnValue.view->getSubViews()[2]->getEntryValue()) == 155;
+                             stoi(testCase.returnValue.view->getSubViews()[2]->getEntryValue(nullptr)) == 155;
                     }
                 })
         );
@@ -2694,8 +2719,8 @@ namespace {
             std::vector<TestCasePredicate>(
                 {
                     [] (const tests::Tests::MethodTestCase& testCase) {
-                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(), "from_bytes<A1::B1>") &&
-                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getEntryValue(), "from_bytes<A1::C1>");
+                      return StringUtils::startsWith(testCase.returnValue.view->getSubViews()[0]->getEntryValue(nullptr), "from_bytes<A1::B1>") &&
+                             StringUtils::startsWith(testCase.returnValue.view->getSubViews()[1]->getEntryValue(nullptr), "from_bytes<A1::C1>");
                     }
                 })
         );

--- a/server/test/framework/Targets_Test.cpp
+++ b/server/test/framework/Targets_Test.cpp
@@ -46,7 +46,7 @@ TEST_F(TargetsTest, Valid_Target_Test_1) {
         checkTestCasePredicates(
             testGen.tests.at(parse_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
-                std::string ret = testCase.returnValue.view->getEntryValue();
+                std::string ret = testCase.returnValue.view->getEntryValue(nullptr);
                 return ret == "\'l\'";
             } }),
             "parse");
@@ -65,7 +65,7 @@ TEST_F(TargetsTest, Valid_Target_Test_1) {
         checkTestCasePredicates(
             testGen.tests.at(parse_c).methods.begin().value().testCases,
             std::vector<TestCasePredicate>({ [](const tests::Tests::MethodTestCase &testCase) {
-                std::string ret = testCase.returnValue.view->getEntryValue();
+                std::string ret = testCase.returnValue.view->getEntryValue(nullptr);
                 return ret == "\'c\'";
             } }),
             "parse");
@@ -97,7 +97,7 @@ TEST_F(TargetsTest, Valid_Target_Test_1) {
         checkTestCasePredicates(
                 testGen.tests.at(parse_c).methods.begin().value().testCases,
                 std::vector<TestCasePredicate>({[](const tests::Tests::MethodTestCase &testCase) {
-                    std::string ret = testCase.returnValue.view->getEntryValue();
+                    std::string ret = testCase.returnValue.view->getEntryValue(nullptr);
                     return ret == "\'c\'" || ret == "\'l\'";
                 }}),
                 "parse");

--- a/server/test/framework/TestUtils.cpp
+++ b/server/test/framework/TestUtils.cpp
@@ -22,9 +22,9 @@ namespace testUtils {
         for (size_t i = 0; i < parameters.size(); i++) {
             ss << "\t\tParameters values: ";
             for (const auto &param : parameters[i]) {
-                ss << param->getEntryValue() << " ";
+                ss << param->getEntryValue(nullptr) << " ";
             }
-            ss << "\n\t\tReturn value: " << returnValues[i]->getEntryValue() << "\n";
+            ss << "\n\t\tReturn value: " << returnValues[i]->getEntryValue(nullptr) << "\n";
         }
         return ss.str();
     }

--- a/server/test/framework/TestUtils.cpp
+++ b/server/test/framework/TestUtils.cpp
@@ -65,6 +65,11 @@ namespace testUtils {
         }
     }
 
+    void checkRegexp(const std::string &value, const std::string &regexp) {
+       ASSERT_TRUE(std::regex_match(value.begin(), value.end(), std::regex(regexp)))
+            << "Value: " << value << "\nDon't correspond to: " << regexp << std::endl;
+    }
+
     void checkCoverage(const Coverage::CoverageMap &coverageMap,
                        const CoverageLines &expectedLinesCovered,
                        const CoverageLines &expectedLinesUncovered,

--- a/server/test/framework/TestUtils.h
+++ b/server/test/framework/TestUtils.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <regex>
 
 using Params = const std::vector<std::shared_ptr<tests::AbstractValueView>> &;
 using ReturnValue = const std::shared_ptr<tests::AbstractValueView> &;
@@ -35,6 +36,9 @@ namespace testUtils {
     void checkTestCasePredicates(const std::vector<tests::Tests::MethodTestCase> &testCases,
                                  const std::vector<TestCasePredicate> &predicates,
                                  const std::string &functionName = "");
+
+    void checkRegexp(const std::string &value,
+                     const std::string &regexp);
 
     void checkCoverage(const Coverage::CoverageMap &coverageMap,
                        const CoverageLines &expectedLinesCovered,


### PR DESCRIPTION
UTBotCpp-253 Better structure fields initialization in generated tests#253

- implemented multiline printer with generation of field prefixes (~ `.field=`)
- separated the cases: c++ initializer-list of a member in constructor/c-like init lists
  (labels like `.field=` are not supported in c++ initializer-list, the comments are used instead)
- test coverage