### PR TITLE
 Publish C/C++ CLI docker images on GitHub Packages

### DIFF
--- a/.github/workflows/publish-c-family-cli-image.yml
+++ b/.github/workflows/publish-c-family-cli-image.yml
@@ -1,0 +1,72 @@
+name: Publish UTBot CLI image
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: utbot_c_family_cli
+  DOCKERFILE_PATH: docker/Dockerfile_c_family_cli
+
+jobs:
+  build-and-publish-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set timezone
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Europe/Moscow"
+
+      - name: Set environment variables
+        run:
+          echo "COMMIT_SHORT_SHA="$(git rev-parse --short HEAD)"" >> $GITHUB_ENV
+
+      - name: Set docker tag
+        run:
+          echo "DOCKER_TAG="$(date +%Y).$(date +%-m).$(date +%-d)-${{ env.COMMIT_SHORT_SHA }}"" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+            
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.DOCKER_TAG }}
+            
+      - name: Docker Buildx (build and push)
+        run: |
+          docker buildx build \
+            -f ${{ env.DOCKERFILE_PATH }} \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
+            --tag ${{ steps.meta.outputs.tags }} \
+            --build-arg ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            --push .       
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/docker/Dockerfile_c_family_cli
+++ b/docker/Dockerfile_c_family_cli
@@ -1,0 +1,35 @@
+FROM ubuntu:bionic-20220531
+
+ARG ACCESS_TOKEN
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+        software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y gcc-9 \
+        g++-9 \
+        curl \
+        unzip \
+        python3 \
+        python3-requests \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
+    && update-alternatives --config gcc \
+    && apt-get clean
+
+WORKDIR /usr/src/
+
+# Install UTBot C/C++ CLI
+COPY docker/get_c_family_cli_download_url.py .
+
+ENV C_FAMILY_CLI_ZIP_NAME "utbot_distr.zip"
+
+RUN curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+        -L $(python3 get_c_family_cli_download_url.py) \
+        -o "${C_FAMILY_CLI_ZIP_NAME}" \
+    && unzip -q "${C_FAMILY_CLI_ZIP_NAME}" \
+    && find . ! -name 'utbot_distr.tar.gz' -type f -exec rm -f {} + \
+    && mkdir utbot-cli \
+    && tar -xf utbot_distr.tar.gz -C utbot-cli \
+    && chmod +x utbot-cli/utbot_distr/utbot_online_cli.sh \
+    && chmod +x utbot-cli/utbot_distr/utbot_run_system.sh

--- a/docker/get_c_family_cli_download_url.py
+++ b/docker/get_c_family_cli_download_url.py
@@ -1,0 +1,13 @@
+import json
+import requests
+
+C_FAMILY_ARTIFACTS_URL="https://api.github.com/repos/UnitTestBot/UTBotCPP/actions/artifacts"
+
+request = requests.get(url = C_FAMILY_ARTIFACTS_URL)
+data = request.json()
+artifacts = data['artifacts']
+
+for artifact in artifacts:
+    if "utbot-dev" in artifact['name']:
+        print(artifact['archive_download_url'])
+        break


### PR DESCRIPTION
# Description

There were added scripts allowing to publish Java CLI images on GitHub Packages.

Fixes #263

# How Has This Been Tested?

## Manual Scenario 

Scripts were tested on fork.