### PR TITLE
[BUG] SARIF report is not recognized by github #352

### DIFF
--- a/server/src/KleeRunner.cpp
+++ b/server/src/KleeRunner.cpp
@@ -45,7 +45,7 @@ void KleeRunner::runKlee(const std::vector<tests::TestMethod> &testMethods,
         fileToMethods[method.sourceFilePath].push_back(method);
     }
 
-    nlohmann::json sarifResults;
+    nlohmann::json sarifResults = nlohmann::json::array();
 
     std::function<void(tests::Tests &tests)> prepareTests = [&](tests::Tests &tests) {
         fs::path filePath = tests.sourceFilePath;

--- a/server/src/SARIFGenerator.cpp
+++ b/server/src/SARIFGenerator.cpp
@@ -35,7 +35,7 @@ namespace sarif {
             }
             ++p;
         }
-        if (foundStartFragment && p == path.end()) {
+        if (p == path.end()) {
             while (s != src.end()) {
                 relToProject = relToProject / *s;
                 ++s;
@@ -77,6 +77,7 @@ namespace sarif {
                                     const fs::path &relPathInProject = getInProjectPath(projectContext.projectPath, srcPath);
                                     const fs::path &fullPathInProject = projectContext.projectPath / relPathInProject;
                                     if (Paths::isSubPathOf(projectContext.buildDir, fullPathInProject)) {
+                                        LOG_S(DEBUG) << "Full path " << fullPathInProject << " is in build - skip it";
                                         continue;
                                     }
                                     if (!relPathInProject.empty() && fs::exists(fullPathInProject)) {
@@ -119,7 +120,7 @@ namespace sarif {
                                         codeFlowsLocations["locations"].push_back(locationWrapper);
                                     } else {
                                         // the rest is the KLEE calls that are not applicable for navigation
-                                        LOG_S(INFO) << "Skip path in stack frame :" << srcPath;
+                                        LOG_S(DEBUG) << "Skip path in stack frame :" << srcPath;
                                     }
                                 }
                             }

--- a/server/src/streams/tests/CLITestsWriter.cpp
+++ b/server/src/streams/tests/CLITestsWriter.cpp
@@ -24,6 +24,13 @@ void CLITestsWriter::writeTestsWithProgress(tests::TestsMap &testMap,
     LOG_S(INFO) << "total test files generated: " << totalTestsCounter;
 }
 
+void CLITestsWriter::writeReport(const std::string &content,
+                                 const std::string &message,
+                                 const fs::path &pathToStore) const {
+    TestsWriter::writeReport(content, message, pathToStore);
+    LOG_S(INFO) << message;
+}
+
 bool CLITestsWriter::writeTestFile(const tests::Tests &tests, const fs::path &testDirPath) {
     fs::path testFilePath = testDirPath / tests.relativeFileDir / tests.testFilename;
     FileSystemUtils::writeToFile(testFilePath, tests.code);

--- a/server/src/streams/tests/CLITestsWriter.h
+++ b/server/src/streams/tests/CLITestsWriter.h
@@ -16,6 +16,10 @@ public:
                                 std::function<void(tests::Tests &)> &&prepareTests,
                                 std::function<void()> &&prepareTotal) override;
 
+    void writeReport(const std::string &content,
+                     const std::string &message,
+                     const fs::path &pathToStore) const override;
+
 private:
     static bool writeTestFile(const tests::Tests &tests, const fs::path &testDirPath);
 };


### PR DESCRIPTION
- `results` entry in json need to be an empy vector, not `null` if no error
- logging was adjusted for CLI mode
- relative path calculation was extended for the case of CLI run inside the project folder