### PR TITLE
[BUG] Bad path entry in `unittestbot.paths.sourceDirectories` parameter on Windows OS #376

### DIFF
--- a/vscode-plugin/src/config/defaultValues.ts
+++ b/vscode-plugin/src/config/defaultValues.ts
@@ -66,7 +66,7 @@ export class DefaultConfigValues {
         if (!rootPath) {
             return buildDirName;
         }
-        await vs.workspace.fs.readDirectory(vs.Uri.parse(rootPath))
+        await vs.workspace.fs.readDirectory(vs.Uri.file(rootPath))
             .then(resultArray => {
                 resultArray.forEach(([name, type]) => {
                     // add only non-hidden directories and not a build directory by default

--- a/vscode-plugin/src/explorer/utbotExplorer.ts
+++ b/vscode-plugin/src/explorer/utbotExplorer.ts
@@ -121,7 +121,7 @@ export class UTBotExplorer {
             }
             const initSourceDirectoriesNames: Array<string> = [];
             await clearSourceDirectories();
-            await vs.workspace.fs.readDirectory(vs.Uri.parse(rootPath))
+            await vs.workspace.fs.readDirectory(vs.Uri.file(rootPath))
                 .then(resultArray => {
                     resultArray.forEach(([name, type]) => {
                         // add only non hidden directories and not a build directory by default

--- a/vscode-plugin/src/explorer/utbotExplorerElement.ts
+++ b/vscode-plugin/src/explorer/utbotExplorerElement.ts
@@ -18,7 +18,7 @@ export class UTBotExplorerFolder extends vs.TreeItem {
     ) {
         super(label, collapsibleState);
         this.tooltip = `${this.path}`;
-        this.description = pathlib.relative(vsUtils.getProjectDirByOpenedFile().fsPath, vs.Uri.parse(this.path).fsPath);
+        this.description = pathlib.relative(vsUtils.getProjectDirByOpenedFile().fsPath, vs.Uri.file(this.path).fsPath);
     }
 
     contextValue = this.isUsed ? UTBotExplorerFolder.UTBOT_FOLDER_USED : UTBotExplorerFolder.UTBOT_FOLDER_NOT_USED;

--- a/vscode-plugin/src/utils/pathUtils.ts
+++ b/vscode-plugin/src/utils/pathUtils.ts
@@ -48,7 +48,7 @@ export function getRealFilePath(editorPath: string, optionalClickedPath: vs.Uri 
 }
 
 export function getRootPath(): string | undefined {
-    return vs.workspace.workspaceFolders?.[0].uri.path;
+    return vs.workspace.workspaceFolders?.[0].uri.fsPath;
 }
 
 export function fsJoin(...paths: string[]): string {


### PR DESCRIPTION
[BUG] Bad path entry in `unittestbot.paths.sourceDirectories` parameter on Windows OS #376

- change path -> fsPath when getting root location