### PR TITLE
backup sarif report

### DIFF
--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/ProjectConfigurationHandler.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/ProjectConfigurationHandler.kt
@@ -15,7 +15,7 @@ import org.utbot.cpp.clion.plugin.utils.notifyError
 import org.utbot.cpp.clion.plugin.utils.notifyInfo
 import org.utbot.cpp.clion.plugin.utils.notifyUnknownResponse
 import org.utbot.cpp.clion.plugin.utils.notifyWarning
-import org.utbot.cpp.clion.plugin.utils.refreshAndFindNioFile
+import org.utbot.cpp.clion.plugin.utils.markDirtyAndRefresh
 import testsgen.Testgen
 
 abstract class ProjectConfigResponseHandler(
@@ -98,7 +98,7 @@ class CreateBuildDirHandler(
             }
             else -> notifyUnknownResponse(response, project)
         }
-        refreshAndFindNioFile(project.settings.buildDirPath)
+        markDirtyAndRefresh(project.settings.buildDirPath)
     }
 }
 
@@ -117,6 +117,6 @@ class GenerateJsonHandler(
             )
             else -> notifyUnknownResponse(response, project)
         }
-        refreshAndFindNioFile(project.settings.buildDirPath)
+        markDirtyAndRefresh(project.settings.buildDirPath)
     }
 }

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/SourceCode.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/SourceCode.kt
@@ -1,0 +1,22 @@
+package org.utbot.cpp.clion.plugin.client.handlers
+
+import com.intellij.openapi.project.Project
+import org.utbot.cpp.clion.plugin.utils.convertFromRemotePathIfNeeded
+import testsgen.Util
+import java.nio.file.Path
+
+class SourceCode private constructor(
+    val localPath: Path,
+    val remotePath: String,
+    val content: String,
+    val regressionMethodsNumber: Int,
+    val errorMethodsNumber: Int
+) {
+    constructor(serverSourceCode: Util.SourceCode, project: Project) : this(
+        serverSourceCode.filePath.convertFromRemotePathIfNeeded(project),
+        serverSourceCode.filePath,
+        serverSourceCode.code,
+        serverSourceCode.regressionMethodsNumber,
+        serverSourceCode.errorMethodsNumber
+    )
+}

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/TestsStreamHandler.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/handlers/TestsStreamHandler.kt
@@ -27,78 +27,83 @@ class TestsStreamHandler(
     private val onSuccess: (List<Path>) -> Unit = {},
     private val onError: (Throwable) -> Unit = {}
 ) : StreamHandlerWithProgress<Testgen.TestsResponse>(project, grpcStream, progressName, cancellationJob) {
+
     private val myGeneratedTestFilesLocalFS: MutableList<Path> = mutableListOf()
+
     override fun onData(data: Testgen.TestsResponse) {
         super.onData(data)
-        val (testSourceCodes, sarifSourceCodes) = data.testSourcesList.map { SourceCode(it, project) }.partition {
-            !it.localPath.isSarifReport()
-        }
+
+        val (testSourceCodes, sarifSourceCodes) = data.testSourcesList
+            .map { SourceCode(it, project) }
+            .partition { !it.localPath.isSarifReport() }
         val stubSourceCodes = data.stubs.stubSourcesList.map { SourceCode(it, project) }
 
-        project.service<TestsResultsStorage>().newTestsGenerated(testSourceCodes)
+        project.service<TestsResultsStorage>().clearTestResults(testSourceCodes)
 
+        //Q: why several sarif source codes? don't we obtain one merged sarif report from server?
         sarifSourceCodes.forEach {
             backupPreviousClientSarifReport(it.localPath)
         }
 
         // if local scenario: server already created files
         if (project.settings.isRemoteScenario) {
-            writeSourceCodes(testSourceCodes, "test")
-            writeSourceCodes(sarifSourceCodes, "sarif report")
-            writeSourceCodes(stubSourceCodes, "stub")
+            createSourceCodeFiles(testSourceCodes, "test")
+            createSourceCodeFiles(sarifSourceCodes, "sarif report")
+            createSourceCodeFiles(stubSourceCodes, "stub")
         }
 
         // prepare list of generated test files for further processing
         myGeneratedTestFilesLocalFS.addAll(testSourceCodes.map { it.localPath })
 
         // log to user
+        //Q: I do not understand this logic, what is the scenarios here?
         testSourceCodes.forEach { sourceCode ->
-            val isTestFileSourceFile = sourceCode.localPath.endsWith("_test.cpp")
-            if (isTestFileSourceFile)
-                project.logger.info {
-                    "Generated test with ${sourceCode.regressionMethodsNumber} tests in regression suite" +
-                            " and ${sourceCode.errorMethodsNumber} tests in error suite"
-                }
-            else
-                project.logger.info { "Generated test file ${sourceCode.localPath}" }
+            val isTestSourceFile = sourceCode.localPath.endsWith("_test.cpp")
+            val testsGenerationResultMessage = if (isTestSourceFile) {
+                "Generated ${sourceCode.regressionMethodsNumber} tests in regression suite" +
+                        " and ${sourceCode.errorMethodsNumber} tests in error suite"
+            } else {
+                "Generated test file ${sourceCode.localPath}"
+            }
+            logger.info(testsGenerationResultMessage)
         }
+
         sarifSourceCodes.forEach {
-            project.logger.info { "Generated SARIF file ${it.localPath}" }
+            project.logger.info { "Generated SARIF report file ${it.localPath}" }
         }
 
         // tell ide to refresh vfs and refresh project tree
         markDirtyAndRefresh(project.nioPath)
     }
 
-    private fun writeSourceCodes(sourceCodes: List<SourceCode>, fileKind: String) {
+    private fun createSourceCodeFiles(sourceCodes: List<SourceCode>, fileKind: String) {
         sourceCodes.forEach {
             project.logger.info { "Write $fileKind file ${it.remotePath} to ${it.localPath}" }
             createFileWithText(it.localPath, it.content)
         }
     }
 
-    override fun Testgen.TestsResponse.getProgress(): Util.Progress {
-        return progress
-    }
+    override fun Testgen.TestsResponse.getProgress(): Util.Progress = progress
 
-    private fun backupPreviousClientSarifReport(oldPath: Path) {
-        fun Number.pad2(): String {
-            return ("0$this").takeLast(2)
-        }
+    private fun backupPreviousClientSarifReport(previousReportPaths: Path) {
+        fun Number.pad2(): String = ("0$this").takeLast(2)
 
-        if (oldPath.exists()) {
-            val ctime = Files.getLastModifiedTime(oldPath)
+        if (previousReportPaths.exists()) {
+            val ctime = Files.getLastModifiedTime(previousReportPaths)
                 .toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime()
-            val newName = "project_code_analysis-" +
+
+            val newReportName = "project_code_analysis-" +
                     ctime.year.toString() +
                     (ctime.monthValue + 1).pad2() +
                     ctime.dayOfMonth.pad2() +
                     ctime.hour.pad2() +
-                    ctime.minute.pad2() + ctime.second.pad2() + ".sarif";
-            val newPath = Paths.get(oldPath.parent.toString(), newName)
-            Files.move(oldPath, newPath)
+                    ctime.minute.pad2() +
+                    ctime.second.pad2() +
+                    ".sarif"
+            val newPath = Paths.get(previousReportPaths.parent.toString(), newReportName)
+            Files.move(previousReportPaths, newPath)
         }
     }
 

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/requests/test/BaseTestsRequest.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/requests/test/BaseTestsRequest.kt
@@ -36,7 +36,7 @@ abstract class BaseTestsRequest<R>(request: R, project: Project, private val pro
     }
 
     open fun getFocusTarget(generatedTestFiles: List<Path>): Path? {
-        return generatedTestFiles.filter { !isHeaderFile(it) && !isSarifReport(it) }.getLongestCommonPathFromRoot()
+        return generatedTestFiles.filter { !isHeaderFile(it) && !it.isSarifReport() }.getLongestCommonPathFromRoot()
     }
 
     override fun logRequest() {

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/requests/test/BaseTestsRequest.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/client/requests/test/BaseTestsRequest.kt
@@ -35,13 +35,10 @@ abstract class BaseTestsRequest<R>(request: R, project: Project, private val pro
         }
     }
 
-    open fun getFocusTarget(generatedTestFiles: List<Path>): Path? {
-        return generatedTestFiles.filter { !isHeaderFile(it) && !it.isSarifReport() }.getLongestCommonPathFromRoot()
-    }
-
-    override fun logRequest() {
-        logger.info { "$logMessage \n$request" }
-    }
+    open fun getFocusTarget(generatedTestFiles: List<Path>): Path? =
+        generatedTestFiles
+            .filter { !isHeaderFile(it) && !it.isSarifReport() }
+            .getLongestCommonPathFromRoot()
 
     open fun getInfoMessage() = "Tests generated!"
 

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/ui/services/TestsResultsStorage.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/ui/services/TestsResultsStorage.kt
@@ -5,9 +5,6 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.newvfs.BulkFileListener
-import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import org.utbot.cpp.clion.plugin.client.handlers.SourceCode
 import org.utbot.cpp.clion.plugin.listeners.UTBotTestResultsReceivedListener
 import org.utbot.cpp.clion.plugin.utils.convertFromRemotePathIfNeeded
@@ -36,8 +33,10 @@ class TestsResultsStorage(val project: Project) {
 
     fun getTestResultByTestName(testName: String): Testgen.TestResultObject? = storage[testName]
 
-    fun newTestsGenerated(sourceCodes: List<SourceCode>) {
-        // for tests that were regenerated forget results from previous test run
+    /**
+     * Cleans the results of previous test run if tests were regenerated.
+     */
+    fun clearTestResults(sourceCodes: List<SourceCode>) {
         val localFilePaths = sourceCodes.map { it.localPath }.toSet()
         storage.values.removeIf { it.testFilePath.convertFromRemotePathIfNeeded(project) in localFilePaths }
     }

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/FileUtils.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/FileUtils.kt
@@ -6,7 +6,7 @@ import com.intellij.util.io.exists
 import kotlin.io.path.writeText
 import java.nio.file.Path
 
-fun refreshAndFindNioFile(path: Path, async: Boolean = true, recursive: Boolean = true, reloadChildren: Boolean = true) {
+fun markDirtyAndRefresh(path: Path, async: Boolean = true, recursive: Boolean = true, reloadChildren: Boolean = true) {
     VfsUtil.markDirtyAndRefresh(async, recursive, reloadChildren, path.toFile())
 }
 
@@ -25,6 +25,6 @@ fun isCPPFileName(fileName: String) = """.*\.(cpp|hpp|h)""".toRegex().matches(fi
 fun isHeaderFile(fileName: String) = """.*\.([ch])""".toRegex().matches(fileName)
 fun isHeaderFile(path: Path) = isHeaderFile(path.fileName.toString())
 
-fun isSarifReport(fileName: String) = fileName.endsWith(".sarif")
+fun String.isSarifReport() = this.endsWith(".sarif")
 
-fun isSarifReport(path: Path) = isSarifReport(path.fileName.toString())
+fun Path.isSarifReport() = this.fileName.toString().isSarifReport()

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/FileUtils.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/FileUtils.kt
@@ -6,9 +6,12 @@ import com.intellij.util.io.exists
 import kotlin.io.path.writeText
 import java.nio.file.Path
 
-fun markDirtyAndRefresh(path: Path, async: Boolean = true, recursive: Boolean = true, reloadChildren: Boolean = true) {
-    VfsUtil.markDirtyAndRefresh(async, recursive, reloadChildren, path.toFile())
-}
+fun markDirtyAndRefresh(
+    path: Path,
+    async: Boolean = true,
+    recursive: Boolean = true,
+    reloadChildren: Boolean = true,
+) = VfsUtil.markDirtyAndRefresh(async, recursive, reloadChildren, path.toFile())
 
 fun createFileWithText(filePath: Path, text: String) {
     with(filePath) {
@@ -24,7 +27,3 @@ fun isCPPFileName(fileName: String) = """.*\.(cpp|hpp|h)""".toRegex().matches(fi
 
 fun isHeaderFile(fileName: String) = """.*\.([ch])""".toRegex().matches(fileName)
 fun isHeaderFile(path: Path) = isHeaderFile(path.fileName.toString())
-
-fun String.isSarifReport() = this.endsWith(".sarif")
-
-fun Path.isSarifReport() = this.fileName.toString().isSarifReport()

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/PathUtils.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/PathUtils.kt
@@ -52,6 +52,8 @@ fun Path.visitAllDirectories(action: (Path) -> Unit) {
     }
 }
 
+fun Path.isSarifReport() = this.fileName.toString().endsWith(".sarif")
+
 fun String.fileNameOrNull(): String? {
     return try {
         Paths.get(this).fileName.toString()

--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/PathUtils.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/utils/PathUtils.kt
@@ -15,6 +15,7 @@ import java.util.*
 import kotlin.io.path.div
 
 val Project.path get() = this.basePath ?: error("Project path can't be null!")
+val Project.nioPath: Path get() = Paths.get(this.path)
 
 fun relativize(from: String, to: String): String {
     val toPath = Paths.get(to)


### PR DESCRIPTION
- In remote scenario: backup previous sarif report (logic of naming old report was taken from VSCode) 
- fix: added newTestsGenerated method to TestsResultStorage in order to update icons to default when new tests are generated
- removed old code from TestsResultStorage related to listening to vfs events