### PR TITLE
fix project view pane is not updated after changing directories in settings

### DIFF
--- a/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/ui/sourceFoldersView/UTBotProjectViewPaneForSettings.kt
+++ b/clion-plugin/src/main/kotlin/org/utbot/cpp/clion/plugin/ui/sourceFoldersView/UTBotProjectViewPaneForSettings.kt
@@ -7,6 +7,7 @@ import org.utbot.cpp.clion.plugin.settings.UTBotProjectStoredSettings
 import org.utbot.cpp.clion.plugin.settings.settings
 import org.utbot.cpp.clion.plugin.utils.localPath
 import javax.swing.tree.DefaultTreeModel
+import org.utbot.cpp.clion.plugin.listeners.SourceFoldersListener
 import org.utbot.cpp.clion.plugin.ui.ObservableValue
 
 open class UTBotProjectViewPaneForSettings(project: Project) : UTBotProjectViewPane(project) {
@@ -36,6 +37,7 @@ open class UTBotProjectViewPaneForSettings(project: Project) : UTBotProjectViewP
 
     fun apply() {
         settings.sourceDirs = sourceDirs.value
+        myProject.messageBus.syncPublisher(SourceFoldersListener.TOPIC).sourceFoldersChanged(settings.sourceDirs)
     }
 
     fun reset() {


### PR DESCRIPTION
bug:

![](https://media4.giphy.com/media/ktve3woCyeVElQWJJ3/giphy.gif)

after fix: 
![](https://media0.giphy.com/media/ROKGRCmvlXqAwpQfpM/giphy.gif?cid=790b7611854a8e54c34951ead7eb5f27b131fcee38e5e2fb&rid=giphy.gif&ct=g)