### PR TITLE
[BUG] Unnecessary "utbot_abs_error" constant added to the test #405

### DIFF
--- a/server/src/Tests.cpp
+++ b/server/src/Tests.cpp
@@ -33,6 +33,13 @@ Tests::MethodDescription::MethodDescription()
                    { Tests::ERROR_SUITE_NAME,   std::string() }},
           modifiers{} { }
 
+static const std::unordered_map<std::string, std::string> FPSpecialValuesMappings = {
+    {"nan", "NAN"},
+    {"-nan", "-NAN"},
+    {"inf", "INFINITY"},
+    {"-inf", "-INFINITY"}
+};
+
 static std::string makeDecimalConstant(std::string value, const std::string &typeName) {
     if (typeName == "long") {
         if (value == INT64_MIN_STRING) {
@@ -55,15 +62,15 @@ static std::string makeDecimalConstant(std::string value, const std::string &typ
     if (typeName == "unsigned long long") {
         return value + "ULL";
     }
+    if (typeName == "long double") {
+        if ( FPSpecialValuesMappings.find(value) == FPSpecialValuesMappings.end()) {
+            // we need it to avoid overflow in exponent for const like 1.18973e+4932L
+            // BUT! Skip the NAN/INFINITY values
+            return value + "L";
+        }
+    }
     return value;
 }
-
-static const std::unordered_map<std::string, std::string> FPSpecialValuesMappings = {
-        {"nan", "NAN"},
-        {"-nan", "-NAN"},
-        {"inf", "INFINITY"},
-        {"-inf", "-INFINITY"}
-};
 
 namespace tests {
 /**

--- a/server/src/clang-utils/SourceToHeaderRewriter.cpp
+++ b/server/src/clang-utils/SourceToHeaderRewriter.cpp
@@ -71,6 +71,7 @@ std::string SourceToHeaderRewriter::generateTestHeader(const fs::path &sourceFil
             sourceFileToInclude =
                 fs::canonical(test.sourceFilePath.parent_path() / test.mainHeader.value().path);
         }
+        sourceFileToInclude = fs::relative(sourceFilePath, test.testHeaderFilePath.parent_path());
         return StringUtils::stringFormat("#define main main__\n\n"
                                          "#include \"%s\"\n\n",
                                          sourceFileToInclude);

--- a/server/src/printers/TestsPrinter.cpp
+++ b/server/src/printers/TestsPrinter.cpp
@@ -48,8 +48,6 @@ void TestsPrinter::joinToFinalCode(Tests &tests, const fs::path& generatedHeader
     genHeaders(tests, generatedHeaderPath);
     ss << "namespace " << PrinterUtils::TEST_NAMESPACE << " {\n";
 
-    strDeclareAbsError(PrinterUtils::ABS_ERROR);
-
     for (const auto &commentBlock : tests.commentBlocks) {
         strComment(commentBlock) << NL;
     }

--- a/server/src/utils/PrinterUtils.cpp
+++ b/server/src/utils/PrinterUtils.cpp
@@ -36,7 +36,6 @@ namespace PrinterUtils {
 
     const std::string EXPECTED = "expected";
     const std::string ACTUAL = "actual";
-    const std::string ABS_ERROR = "utbot_abs_error";
     const std::string EXPECT_ = "EXPECT_";
     const std::string EXPECT_FLOAT_EQ  = "EXPECT_FLOAT_EQ";
     const std::string EXPECT_DOUBLE_EQ = "EXPECT_DOUBLE_EQ";

--- a/server/src/utils/PrinterUtils.cpp
+++ b/server/src/utils/PrinterUtils.cpp
@@ -38,6 +38,8 @@ namespace PrinterUtils {
     const std::string ACTUAL = "actual";
     const std::string ABS_ERROR = "utbot_abs_error";
     const std::string EXPECT_ = "EXPECT_";
+    const std::string EXPECT_FLOAT_EQ  = "EXPECT_FLOAT_EQ";
+    const std::string EXPECT_DOUBLE_EQ = "EXPECT_DOUBLE_EQ";
     const std::string EQ = "EQ";
 
     std::string convertToBytesFunctionName(const std::string &typeName) {

--- a/server/src/utils/PrinterUtils.h
+++ b/server/src/utils/PrinterUtils.h
@@ -32,7 +32,6 @@ namespace PrinterUtils {
     extern const std::string EXPECT_DOUBLE_EQ;
 
     extern const std::string ACTUAL;
-    extern const std::string ABS_ERROR;
     extern const std::string EXPECT_;
     extern const std::string EQ;
 

--- a/server/src/utils/PrinterUtils.h
+++ b/server/src/utils/PrinterUtils.h
@@ -23,10 +23,14 @@ namespace PrinterUtils {
     extern const std::string KLEE_PATH_FLAG;
     extern const std::string KLEE_PATH_FLAG_SYMBOLIC;
     extern const std::string EQ_OPERATOR;
+
     extern const std::string ASSIGN_OPERATOR;
     extern const std::string TAB;
 
     extern const std::string EXPECTED;
+    extern const std::string EXPECT_FLOAT_EQ;
+    extern const std::string EXPECT_DOUBLE_EQ;
+
     extern const std::string ACTUAL;
     extern const std::string ABS_ERROR;
     extern const std::string EXPECT_;

--- a/server/src/visitors/AssertsVisitor.cpp
+++ b/server/src/visitors/AssertsVisitor.cpp
@@ -30,16 +30,16 @@ namespace visitor {
 
     AssertsVisitor::FunctionSignature AssertsVisitor::processExpect(
         const types::Type &type, const std::string &gtestMacro, std::vector<std::string> &&args) {
+        std::string macroName = PrinterUtils::EXPECT_ + gtestMacro;
         if (types::TypesHandler::isFloatingPointType(type) && gtestMacro == PrinterUtils::EQ) {
             const types::TypeName &typeName = type.baseType();
             if (typeName == "float") {
-                return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_FLOAT_EQ, std::move(args) };
-            }
-            if (typeName == "double" || typeName == "long double") {
-                return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_DOUBLE_EQ, std::move(args) };
+                macroName = PrinterUtils::EXPECT_FLOAT_EQ;
+            } else if (typeName == "double" || typeName == "long double") {
+                macroName = PrinterUtils::EXPECT_DOUBLE_EQ;
             }
         }
-        return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_ + gtestMacro, std::move(args) };
+        return VerboseAssertsVisitor::FunctionSignature{ macroName, std::move(args) };
     }
 
     std::string AssertsVisitor::getDecorateActualVarName(const std::string &access) {

--- a/server/src/visitors/AssertsVisitor.cpp
+++ b/server/src/visitors/AssertsVisitor.cpp
@@ -30,13 +30,16 @@ namespace visitor {
 
     AssertsVisitor::FunctionSignature AssertsVisitor::processExpect(
         const types::Type &type, const std::string &gtestMacro, std::vector<std::string> &&args) {
-        bool changePredicate = types::TypesHandler::isFloatingPointType(type) && (gtestMacro == PrinterUtils::EQ);
-        std::string targetMacro = gtestMacro;
-        if (changePredicate) {
-            targetMacro = "NEAR";
-            args.emplace_back(PrinterUtils::ABS_ERROR);
+        if (types::TypesHandler::isFloatingPointType(type) && gtestMacro == PrinterUtils::EQ) {
+            const types::TypeName &typeName = type.baseType();
+            if (typeName == "float") {
+                return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_FLOAT_EQ, std::move(args) };
+            }
+            if (typeName == "double" || typeName == "long double") {
+                return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_DOUBLE_EQ, std::move(args) };
+            }
         }
-        return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_ + targetMacro, std::move(args) };
+        return VerboseAssertsVisitor::FunctionSignature{ PrinterUtils::EXPECT_ + gtestMacro, std::move(args) };
     }
 
     std::string AssertsVisitor::getDecorateActualVarName(const std::string &access) {

--- a/server/test/framework/Syntax_Tests.cpp
+++ b/server/test/framework/Syntax_Tests.cpp
@@ -1693,12 +1693,18 @@ namespace {
 
 
         ASSERT_TRUE(status.ok()) << status.error_message();
+
+        printer::TestsPrinter testsPrinter(nullptr, utbot::Language::C);
+        const auto &tests = testGen.tests.at(floats_special_c)
+                                .methods.begin().value().testCases;
         checkTestCasePredicates(
-                testGen.tests.at(floats_special_c).methods.begin().value().testCases,
-                std::vector<TestCasePredicate>(
-                        {[](const tests::Tests::MethodTestCase &testCase) {
+            tests, std::vector<TestCasePredicate>(
+                       { [](const tests::Tests::MethodTestCase &testCase) {
                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "NAN";
-                        }}));
+                         },
+                         [](const tests::Tests::MethodTestCase &testCase) {
+                             return testCase.paramValues[0].view->getEntryValue(nullptr) == "0.000000e+00L";
+                         } }));
     }
 
     TEST_F(Syntax_Test, Floats_Special_Values_Inf) {

--- a/server/test/suites/coverage/pregenerated_tests/dependent_functions_dot_c_test.cpp
+++ b/server/test/suites/coverage/pregenerated_tests/dependent_functions_dot_c_test.cpp
@@ -2,7 +2,6 @@
 
 #include "gtest/gtest.h"
 namespace UTBot {
-    static const float utbot_abs_error = 1e-6;
 
 
 

--- a/server/test/suites/coverage/pregenerated_tests/simple_class_dot_cpp_test.cpp
+++ b/server/test/suites/coverage/pregenerated_tests/simple_class_dot_cpp_test.cpp
@@ -7,7 +7,6 @@
 ACCESS_PRIVATE_FIELD(Point_2d, int, x);
 
 namespace UTBot {
-  static const float utbot_abs_error = 1e-6;
 
 
 
@@ -67,7 +66,7 @@ namespace UTBot {
   {
       Point_2d Point_2d_obj;
       double actual = Point_2d_obj.get_dist_to_zero();
-      EXPECT_NEAR(-0.000000e+00, actual, utbot_abs_error);
+      EXPECT_DOUBLE_EQ(-0.000000e+00, actual);
   }
 
 
@@ -106,7 +105,7 @@ namespace UTBot {
       class Point_2d lhs = {0, 0};
       class Point_2d rhs = {0, 0};
       double actual = get_dist(lhs, rhs);
-      EXPECT_NEAR(0.000000e+00, actual, utbot_abs_error);
+      EXPECT_DOUBLE_EQ(0.000000e+00, actual);
       class Point_2d expected_lhs = {0, 0};
       EXPECT_EQ(access_private::x(expected_lhs), access_private::x(lhs));
       EXPECT_EQ(expected_lhs.y, lhs.y);

--- a/server/test/suites/syntax/floats_special.c
+++ b/server/test/suites/syntax/floats_special.c
@@ -9,7 +9,7 @@ int is_nanf(float x) {
     }
 }
 
-int is_nan(double x) {
+int is_nan(long double x) {
     if (x != x) {
         return 1;
     } else {

--- a/server/test/suites/syntax/floats_special.h
+++ b/server/test/suites/syntax/floats_special.h
@@ -2,7 +2,7 @@
 #define UNITTESTBOT_FLOATS_SPECIAL_H
 
 int is_nanf(float x);
-int is_nan(double x);
+int is_nan(long double x);
 int is_inf(float x);
 
 #endif //UNITTESTBOT_FLOATS_SPECIAL_H


### PR DESCRIPTION
- use `EXPECT_FLOAT_EQ` and `EXPECT_DOUBLE_EQ` instead of `EXPECT_NEAR`
- remove insertion obsolete `utbot_abs_error` to the code
- support comparison `NAN` and `INFINITY` consts
- make inclusion of `main.c` wrapper with relative path