### PR TITLE
Fail run test for function sumSignArray [BUG] #464

### DIFF
--- a/server/src/types/TypesResolver.cpp
+++ b/server/src/types/TypesResolver.cpp
@@ -224,7 +224,7 @@ void TypesResolver::resolveEnum(const clang::EnumDecl *EN, const std::string &na
     enumInfo.filePath = Paths::getCCJsonFileFullPath(
         sourceManager.getFilename(EN->getLocation()).str(), parent->buildRootPath.string());
     clang::QualType promotionType = EN->getPromotionType();
-    enumInfo.size = context.getTypeSize(promotionType) / 8;
+    enumInfo.size = context.getTypeSize(promotionType);
 
     enumInfo.access = getAccess(EN);
 


### PR DESCRIPTION
- currently the size is stored in bytes: fix regression from `Support bit field in struct #237`