### PR TITLE
[BUG] No tests generated for function calling function from another module #517

### DIFF
--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -257,7 +257,7 @@ Status Server::TestsGenServiceImpl::ProcessBaseTestRequest(BaseTestGen &testGen,
         auto generator = std::make_shared<KleeGenerator>(&testGen, typesHandler, pathSubstitution);
 
         ReturnTypesFetcher returnTypesFetcher{&testGen};
-        returnTypesFetcher.fetch(testGen.progressWriter, synchronizer.getSourceFiles());
+        returnTypesFetcher.fetch(testGen.progressWriter, synchronizer.getTargetSourceFiles());
         LOG_S(DEBUG) << "Temporary build directory path: " << testGen.serverBuildDir;
         generator->buildKleeFiles(testGen.tests, lineInfo);
         generator->handleFailedFunctions(testGen.tests);

--- a/server/src/Synchronizer.h
+++ b/server/src/Synchronizer.h
@@ -56,7 +56,8 @@ public:
 
     void synchronize(const types::TypesHandler &typesHandler);
 
-    [[nodiscard]] const CollectionUtils::FileSet &getSourceFiles() const;
+    [[nodiscard]] const CollectionUtils::FileSet &getTargetSourceFiles() const;
+    [[nodiscard]] const CollectionUtils::FileSet &getProjectSourceFiles() const;
     [[nodiscard]] std::unordered_set<StubOperator, HashUtils::StubHash> getStubsFiles() const;
 };
 


### PR DESCRIPTION
closes #517 

The problem was in stubs synchronization. When server synced stubs it deleted all files that are not in current target in function `prepareDirectory()`, though those stubs could be needed later