### PR TITLE
TestsPrinters.cpp: add FAIL() assertion to error tests.

### DIFF
--- a/server/src/printers/TestsPrinter.cpp
+++ b/server/src/printers/TestsPrinter.cpp
@@ -238,13 +238,10 @@ void TestsPrinter::genVerboseTestCase(const Tests::MethodDescription &methodDesc
     TestsPrinter::verboseFunctionCall(methodDescription, testCase);
     markTestedFunctionCallIfNeed(methodDescription.name, testCase);
 
-    ss << NL;
     if (testCase.isError()) {
-        ss << LINE_INDENT()
-           << "FAIL() << \"Unreachable point. "
-              "Function was supposed to fail, but actually completed successfully.\""
-           << SCNL;
+        printFailAssertion();
     } else {
+        ss << NL;
         TestsPrinter::verboseAsserts(methodDescription, testCase, predicateInfo);
     }
     ss << RB() << NL;
@@ -667,6 +664,8 @@ void TestsPrinter::parametrizedAsserts(const Tests::MethodDescription &methodDes
         globalParamsAsserts(methodDescription, testCase);
         classAsserts(methodDescription, testCase);
         changeableParamsAsserts(methodDescription, testCase);
+    } else {
+        printFailAssertion();
     }
 }
 
@@ -761,6 +760,15 @@ void printer::TestsPrinter::parametrizedInitializeSymbolicStubs(const Tests::Met
         const auto &value = testCase.stubValues[i];
         verboseParameter(methodDescription, param, value, false);
     }
+}
+
+void TestsPrinter::printFailAssertion() {
+    ss << NL;
+    ss << LINE_INDENT()
+       << "FAIL() << \"Unreachable point or the function was supposed to fail, but \"\n"
+       << LINE_INDENT() << LINE_INDENT()
+       << "\"actually completed successfully. See the SARIF report for details.\"";
+    ss << SCNL;
 }
 
 std::string printer::MultiLinePrinter::print(TestsPrinter *printer,

--- a/server/src/printers/TestsPrinter.h
+++ b/server/src/printers/TestsPrinter.h
@@ -158,6 +158,8 @@ namespace printer {
                                 int &testNum);
 
         std::uint32_t printSuiteAndReturnMethodsCount(const std::string &suiteName, const Tests::MethodsMap &methods);
+
+        void printFailAssertion();
     };
 }
 #endif // UNITTESTBOT_TESTSPRINTER_H

--- a/server/test/framework/Syntax_Tests.cpp
+++ b/server/test/framework/Syntax_Tests.cpp
@@ -4,13 +4,14 @@
 #include "KleeGenerator.h"
 #include "Server.h"
 #include "TestUtils.h"
-#include "streams/coverage/ServerCoverageAndResultsWriter.h"
-#include "coverage/CoverageAndResultsGenerator.h"
-
-#include "utils/path/FileSystemPath.h"
-#include "utils/StringUtils.h"
-#include "utils/SizeUtils.h"
 #include "Tests.h"
+#include "coverage/CoverageAndResultsGenerator.h"
+#include "gmock/gmock.h"
+#include "streams/coverage/ServerCoverageAndResultsWriter.h"
+#include "utils/SizeUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/path/FileSystemPath.h"
+
 #include <functional>
 
 namespace {
@@ -1335,6 +1336,18 @@ namespace {
         auto [testGen, status] = createTestForFunction(structs_with_pointers_c, 111);
 
         ASSERT_TRUE(status.ok()) << status.error_message();
+    }
+
+    TEST_F(Syntax_Test, Check_Error_Tests_Have_Fail_Assertion) {
+        auto [testGen, status] = createTestForFunction(structs_with_pointers_c, 111);
+
+        ASSERT_TRUE(status.ok()) << status.error_message();
+
+        for (const auto &[source_file_path, tests] : testGen.tests) {
+            EXPECT_THAT(tests.code,
+                        ::testing::HasSubstr(
+                            "FAIL() << \"Unreachable point or the function was supposed to fail"));
+        }
     }
 
     TEST_F(Syntax_Test, Pass_Pointer_To_Const_Struct_With_Pointer) {


### PR DESCRIPTION
Add FAIL() assertion to generated tests in no verbose mode. The line with FAIL() assertion is unreachable in some tests but it gives additional information to the user to make the tests easier to read.

I add a unit test to check that the code of generated tests (error suit) has the line with FAIL() assertion. I decided not to use statuses from the tests execution because the line with FAIL() assertion can be unreachable.

Refs: #472