### PR TITLE
Changes for using UTBotCPP on scalapack project.

### DIFF
--- a/.github/workflows/build-utbot.yml
+++ b/.github/workflows/build-utbot.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-portable-container:
     needs: build-utbot-and-generate-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20
     env:
       DOCKER_IMAGE_TAG: docker-image
       PORTABLE_CONTAINER_NAME: Portable

--- a/.github/workflows/build-utbot.yml
+++ b/.github/workflows/build-utbot.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-portable-container:
     needs: build-utbot-and-generate-test
-    runs-on: ubuntu-20
+    runs-on: ubuntu-20.04
     env:
       DOCKER_IMAGE_TAG: docker-image
       PORTABLE_CONTAINER_NAME: Portable

--- a/.github/workflows/publish-utbot.yml
+++ b/.github/workflows/publish-utbot.yml
@@ -91,7 +91,7 @@ jobs:
 
   auto_installation_check:
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/server/src/Paths.cpp
+++ b/server/src/Paths.cpp
@@ -51,6 +51,10 @@ namespace Paths {
         return m.first == base.end();
     }
 
+    bool skipFile(const fs::path &file) {
+        return file.string().substr(file.string().size() - 4) == ".f.o";
+    }
+
     fs::path longestCommonPrefixPath(const fs::path &a, const fs::path &b) {
         if (a == b) {
             return a;

--- a/server/src/Paths.h
+++ b/server/src/Paths.h
@@ -101,6 +101,8 @@ namespace Paths {
 
     bool isSubPathOf(const fs::path &base, const fs::path &sub);
 
+    bool skipFile(const fs::path &file);
+
     fs::path longestCommonPrefixPath(const fs::path &a, const fs::path &b);
 
     static inline fs::path replaceExtension(const fs::path &path, const std::string &newExt) {

--- a/server/src/building/BuildDatabase.cpp
+++ b/server/src/building/BuildDatabase.cpp
@@ -432,6 +432,9 @@ bool BuildDatabase::ObjectFileInfo::is32bits() const {
 }
 
 fs::path BuildDatabase::TargetInfo::getOutput() const {
+    if (commands.empty()){
+        throw CompilationDatabaseException("There are no targets");
+    }
     return commands[0].getOutput();
 }
 

--- a/server/src/building/ProjectBuildDatabse.cpp
+++ b/server/src/building/ProjectBuildDatabse.cpp
@@ -171,7 +171,7 @@ void ProjectBuildDatabase::initInfo(const nlohmann::json &linkCommandsJson) {
         for (nlohmann::json const &jsonFile: linkCommand.at("files")) {
             auto filename = jsonFile.get<std::string>();
             fs::path currentFile = Paths::getCCJsonFileFullPath(filename, command.getDirectory());
-            if (currentFile.string().substr(currentFile.string().size() - 4) == ".f.o"){
+            if (Paths::skipFile(currentFile)){
                 continue;
             }
             targetInfo->addFile(currentFile);

--- a/server/src/building/ProjectBuildDatabse.cpp
+++ b/server/src/building/ProjectBuildDatabse.cpp
@@ -130,9 +130,9 @@ void ProjectBuildDatabase::initObjects(const nlohmann::json &compileCommandsJson
             objectFileInfos[outputFile] = objectInfo;
         }
         const fs::path &sourcePath = objectInfo->getSourcePath();
-        if (Paths::isSourceFile(sourcePath)){
-            sourceFileInfos[sourcePath].emplace_back(objectInfo);
-        }
+
+        sourceFileInfos[sourcePath].emplace_back(objectInfo);
+
     }
     for (auto &[sourceFile, objectInfos]: sourceFileInfos) {
         std::sort(objectInfos.begin(), objectInfos.end(), BuildDatabase::ObjectFileInfo::conflictPriorityMore);

--- a/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.cpp
@@ -394,6 +394,14 @@ std::string SourceToHeaderMatchCallback::getOldStyleDeclarationAsString(const Fu
     return result;
 }
 
+/*Example of old style definition
+int sum(a, b)
+int a;
+int b;
+{
+    return a + b;
+}
+*/
 bool SourceToHeaderMatchCallback::IsOldStyleDefinition(std::string const &definition) const{
     std::regex normStyle ("\\([a-zA-Z0-9*&_()\\[\\]]+ [a-zA-Z0-9*&_()\\[\\]]+[,) ]");
     bool res = std::regex_search(definition, normStyle);

--- a/server/src/clang-utils/SourceToHeaderMatchCallback.h
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.h
@@ -87,6 +87,8 @@ private:
     void renameDecl(const clang::NamedDecl *decl, const std::string &name) const;
 
     std::string decorate(std::string_view name) const;
+
+    std::string getDeclarationAsString(const clang::FunctionDecl *decl, std::string const &name) const;
 };
 
 

--- a/server/src/clang-utils/SourceToHeaderMatchCallback.h
+++ b/server/src/clang-utils/SourceToHeaderMatchCallback.h
@@ -88,7 +88,9 @@ private:
 
     std::string decorate(std::string_view name) const;
 
-    std::string getDeclarationAsString(const clang::FunctionDecl *decl, std::string const &name) const;
+    std::string getOldStyleDeclarationAsString(const clang::FunctionDecl *decl, std::string const &name) const;
+
+    bool IsOldStyleDefinition(std::string const &definition) const;
 };
 
 

--- a/server/src/fetchers/FunctionDeclsMatchCallback.cpp
+++ b/server/src/fetchers/FunctionDeclsMatchCallback.cpp
@@ -91,8 +91,8 @@ void FunctionDeclsMatchCallback::run(const MatchFinder::MatchResult &Result) {
 
         const auto paramsFromDefinition = FS->parameters();
         const auto paramsFromDeclaration = FSFromHeader->parameters();
-        for (size_t i = 0; i < paramsFromDeclaration.size(); ++i) {
-            const auto &declParam = paramsFromDeclaration[i];
+        for (size_t i = 0; i < paramsFromDefinition.size(); ++i) {
+//            const auto &declParam = paramsFromDeclaration[i];
             const auto &defParam = paramsFromDefinition[i];
             std::string name = NameDecorator::decorate(defParam->getNameAsString());
             std::string mangledName = PrinterUtils::getParamMangledName(name, methodName);
@@ -102,9 +102,9 @@ void FunctionDeclsMatchCallback::run(const MatchFinder::MatchResult &Result) {
             if (name == methodDescription.name) {
                 name = mangledName;
             }
-            auto paramType = ParamsHandler::getType(defParam->getType(), declParam->getType(), sourceManager);
-            addFunctionPointer(methodDescription.functionPointers, declParam->getFunctionType(),
-                               declParam->getType(), name, sourceManager, paramType);
+            auto paramType = ParamsHandler::getType(defParam->getType(), defParam->getType(), sourceManager);
+            addFunctionPointer(methodDescription.functionPointers, defParam->getFunctionType(),
+                               defParam->getType(), name, sourceManager, paramType);
             auto alignment = AlignmentFetcher::fetch(defParam);
             bool hasIncompleteType = ClangUtils::isIncomplete(defParam->getType());
             methodDescription.params.emplace_back(paramType, name, alignment, hasIncompleteType);

--- a/server/src/fetchers/FunctionDeclsMatchCallback.cpp
+++ b/server/src/fetchers/FunctionDeclsMatchCallback.cpp
@@ -89,10 +89,8 @@ void FunctionDeclsMatchCallback::run(const MatchFinder::MatchResult &Result) {
                 ASTPrinter::getSourceText(FS->getBody()->getSourceRange(), sourceManager);
         }
 
-        const auto paramsFromDefinition = FS->parameters();
-        const auto paramsFromDeclaration = FSFromHeader->parameters();
+        const auto paramsFromDefinition = FS->parameters();;
         for (size_t i = 0; i < paramsFromDefinition.size(); ++i) {
-//            const auto &declParam = paramsFromDeclaration[i];
             const auto &defParam = paramsFromDefinition[i];
             std::string name = NameDecorator::decorate(defParam->getNameAsString());
             std::string mangledName = PrinterUtils::getParamMangledName(name, methodName);

--- a/server/src/fetchers/FunctionDeclsMatchCallback.cpp
+++ b/server/src/fetchers/FunctionDeclsMatchCallback.cpp
@@ -89,7 +89,7 @@ void FunctionDeclsMatchCallback::run(const MatchFinder::MatchResult &Result) {
                 ASTPrinter::getSourceText(FS->getBody()->getSourceRange(), sourceManager);
         }
 
-        const auto paramsFromDefinition = FS->parameters();;
+        const auto paramsFromDefinition = FS->parameters();
         for (size_t i = 0; i < paramsFromDefinition.size(); ++i) {
             const auto &defParam = paramsFromDefinition[i];
             std::string name = NameDecorator::decorate(defParam->getNameAsString());


### PR DESCRIPTION
This PR fixes several problems that appeared on the project scalapack:
1) Avoid .f and .f.o files as source files.
2) Use definition parameters (cause due to "extern func();" declaration function`s parameters were lost)
3) Fix wrong test header and wrapper printing due to old style function definition.