### PR TITLE
Fix target selection for files and lines (closes #557)

### DIFF
--- a/.github/workflows/build-utbot.yml
+++ b/.github/workflows/build-utbot.yml
@@ -153,7 +153,7 @@ jobs:
 
   build-portable-container:
     needs: build-utbot-and-generate-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKER_IMAGE_TAG: docker-image
       PORTABLE_CONTAINER_NAME: Portable

--- a/server/src/building/TargetBuildDatabase.cpp
+++ b/server/src/building/TargetBuildDatabase.cpp
@@ -19,7 +19,7 @@ TargetBuildDatabase::TargetBuildDatabase(BuildDatabase *baseBuildDatabase, const
         }
     }
 
-    isAutoTarget = target == GrpcUtils::UTBOT_AUTO_TARGET_PATH;
+    LOG_S(INFO) << StringUtils::stringFormat("Chosen target: %s", target);
 
     {
         auto objectFilesList = baseBuildDatabase->getArchiveObjectFiles(target);

--- a/server/src/building/TargetBuildDatabase.h
+++ b/server/src/building/TargetBuildDatabase.h
@@ -7,7 +7,7 @@
 class TargetBuildDatabase : public BuildDatabase {
 private:
     fs::path target;
-    bool isAutoTarget;
+    bool isAutoTarget = false;
 
 public:
     TargetBuildDatabase(BuildDatabase *baseBuildDatabase, const std::string &targetOrSourcePath);

--- a/server/src/testgens/FileTestGen.cpp
+++ b/server/src/testgens/FileTestGen.cpp
@@ -5,7 +5,7 @@
 FileTestGen::FileTestGen(const testsgen::FileRequest &request,
                          ProgressWriter *progressWriter,
                          bool testMode)
-        : ProjectTestGen(request.projectrequest(), progressWriter, testMode, false),
+        : ProjectTestGen(request.projectrequest(), progressWriter, testMode, false, fs::weakly_canonical(request.filepath())),
           filepath(fs::weakly_canonical(request.filepath())) {
     testingMethodsSourcePaths = {filepath};
     setInitializedTestsMap();

--- a/server/src/testgens/LineTestGen.cpp
+++ b/server/src/testgens/LineTestGen.cpp
@@ -3,7 +3,7 @@
 LineTestGen::LineTestGen(const testsgen::LineRequest &request,
                          ProgressWriter *progressWriter,
                          bool testMode, bool forHeader)
-        : ProjectTestGen(request.projectrequest(), progressWriter, testMode, false) {
+        : ProjectTestGen(request.projectrequest(), progressWriter, testMode, false, fs::weakly_canonical(request.sourceinfo().filepath())) {
     filePath = fs::weakly_canonical(request.sourceinfo().filepath());
     line = request.sourceinfo().line();
     std::optional<fs::path> sourcePath = Paths::headerPathToSourcePath(filePath);

--- a/server/src/testgens/ProjectTestGen.cpp
+++ b/server/src/testgens/ProjectTestGen.cpp
@@ -8,7 +8,8 @@
 ProjectTestGen::ProjectTestGen(const testsgen::ProjectRequest &request,
                                ProgressWriter *progressWriter,
                                bool testMode,
-                               bool autoDetect)
+                               bool autoDetect,
+                               const std::optional<fs::path> &sourceFile)
         : BaseTestGen(request.projectcontext(),
                       request.settingscontext(),
                       progressWriter,
@@ -16,7 +17,12 @@ ProjectTestGen::ProjectTestGen(const testsgen::ProjectRequest &request,
     fs::create_directories(projectContext.testDirPath);
     compileCommandsJsonPath = CompilationUtils::substituteRemotePathToCompileCommandsJsonPath(projectContext);
     projectBuildDatabase = std::make_shared<ProjectBuildDatabase>(compileCommandsJsonPath, serverBuildDir, projectContext);
-    targetBuildDatabase = std::make_shared<TargetBuildDatabase>(projectBuildDatabase.get(), request.targetpath());
+    if (sourceFile.has_value() && Paths::isSourceFile(sourceFile.value()) &&
+       (request.targetpath() == GrpcUtils::UTBOT_AUTO_TARGET_PATH || request.targetpath().empty())) {
+        targetBuildDatabase = std::make_shared<TargetBuildDatabase>(projectBuildDatabase.get(), sourceFile.value());
+    } else {
+        targetBuildDatabase = std::make_shared<TargetBuildDatabase>(projectBuildDatabase.get(), request.targetpath());
+    }
     if (autoDetect) {
         autoDetectSourcePathsIfNotEmpty();
     } else {

--- a/server/src/testgens/ProjectTestGen.h
+++ b/server/src/testgens/ProjectTestGen.h
@@ -10,7 +10,8 @@ public:
     ProjectTestGen(const testsgen::ProjectRequest &request,
                    ProgressWriter *progressWriter,
                    bool testMode,
-                   bool autoDetect = true);
+                   bool autoDetect = true,
+                   const std::optional<fs::path> &sourceFile = std::nullopt);
 
     ~ProjectTestGen() override = default;
 

--- a/server/test/framework/Server_Tests.cpp
+++ b/server/test/framework/Server_Tests.cpp
@@ -116,7 +116,6 @@ namespace {
                     createProjectRequest(projectName, suitePath, buildDirRelativePath, srcPaths);
             auto request = GrpcUtils::createFileRequest(std::move(projectRequest), filename);
             auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-            testGen.setTargetForSource(filename);
             Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
             return FileGenResult(testGen, status);
         }
@@ -980,7 +979,6 @@ namespace {
             createProjectRequest(projectName, suitePath, buildDirRelativePath, srcPaths);
         auto request = GrpcUtils::createFileRequest(std::move(projectRequest), basic_functions_c);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1004,7 +1002,6 @@ namespace {
         auto request = createLineRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                          basic_functions_c, 17, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false, false, 0);
         auto testGen = LineTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1021,7 +1018,6 @@ namespace {
         auto request = createLineRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                          basic_functions_c, 17, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false, false, 0);
         auto testGen = LineTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1039,7 +1035,6 @@ namespace {
         auto request = createClassRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                           multiple_classes_h, 6);
         auto testGen = ClassTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(multiple_classes_cpp);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1054,7 +1049,6 @@ namespace {
         auto request = createClassRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                           multiple_classes_h, 11);
         auto testGen = ClassTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(multiple_classes_cpp);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1069,7 +1063,6 @@ namespace {
         auto request = createClassRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                           multiple_classes_h, 14);
         auto testGen = ClassTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(multiple_classes_cpp);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
 
@@ -1085,7 +1078,6 @@ namespace {
                                              basic_functions_c, 6, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false, false, 0);
         auto request = GrpcUtils::createFunctionRequest(std::move(lineRequest));
         auto testGen = FunctionTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -1118,7 +1110,6 @@ namespace {
         auto request =
             GrpcUtils::createPredicateRequest(std::move(lineRequest), std::move(predicateInfo));
         auto testGen = PredicateTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -1141,7 +1132,6 @@ namespace {
         auto request =
             GrpcUtils::createPredicateRequest(std::move(lineRequest), std::move(predicateInfo));
         auto testGen = PredicateTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(basic_functions_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -1160,7 +1150,6 @@ namespace {
                                              symbolic_stdin_c, 8, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false, false, 0);
         request->set_allocated_linerequest(lineRequest.release());
         auto testGen = FunctionTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(symbolic_stdin_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -1182,7 +1171,6 @@ namespace {
                                              symbolic_stdin_c, 19, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false, false, 0);
         request->set_allocated_linerequest(lineRequest.release());
         auto testGen = FunctionTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(symbolic_stdin_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();

--- a/server/test/framework/Stub_Tests.cpp
+++ b/server/test/framework/Stub_Tests.cpp
@@ -127,7 +127,6 @@ namespace {
         auto request = createFileRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                          literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(literals_foo_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -140,7 +139,6 @@ namespace {
             auto request = createFileRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                              literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
             auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-            testGen.setTargetForSource(literals_foo_c);
 
             Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
             ASSERT_TRUE(status.ok()) << status.error_message();
@@ -151,7 +149,6 @@ namespace {
             auto request = createFileRequest(projectName, suitePath, buildDirRelativePath,
                                               srcPaths, literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
             auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-            testGen.setTargetForSource(literals_foo_c);
 
             Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
             ASSERT_TRUE(status.ok()) << status.error_message();
@@ -218,7 +215,6 @@ namespace {
         auto request = testUtils::createFileRequest(projectName, suitePath, buildDirRelativePath,
                                                    srcPaths, calc_sum_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(calc_sum_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
         EXPECT_GE(testUtils::getNumberOfTests(testGen.tests), 2);
@@ -239,7 +235,6 @@ namespace {
         auto request = testUtils::createFileRequest(projectName, suitePath, buildDirRelativePath,
                                                     srcPaths, literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, false);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(literals_foo_c);
 
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
@@ -283,7 +278,6 @@ namespace {
             auto request = createFileRequest(projectName, suitePath, buildDirRelativePath, srcPaths,
                                              literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
             auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-            testGen.setTargetForSource(literals_foo_c);
 
             Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
             ASSERT_TRUE(status.ok()) << status.error_message();
@@ -292,7 +286,6 @@ namespace {
             auto request = createFileRequest(projectName, suitePath, buildDirRelativePath,
                                              srcPaths, literals_foo_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true);
             auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-            testGen.setTargetForSource(literals_foo_c);
 
             Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
             ASSERT_TRUE(status.ok()) << status.error_message();

--- a/server/test/framework/Syntax_Tests.cpp
+++ b/server/test/framework/Syntax_Tests.cpp
@@ -2240,7 +2240,6 @@ namespace {
                                                     srcPaths, linked_list_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true,
                                                     false);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(linked_list_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
         EXPECT_GE(testUtils::getNumberOfTests(testGen.tests), 2);
@@ -2273,7 +2272,6 @@ namespace {
         auto request = testUtils::createFileRequest(projectName, suitePath, buildDirRelativePath,
                                                     srcPaths, tree_c, GrpcUtils::UTBOT_AUTO_TARGET_PATH, true, false);
         auto testGen = FileTestGen(*request, writer.get(), TESTMODE);
-        testGen.setTargetForSource(tree_c);
         Status status = Server::TestsGenServiceImpl::ProcessBaseTestRequest(testGen, writer.get());
         ASSERT_TRUE(status.ok()) << status.error_message();
         EXPECT_GE(testUtils::getNumberOfTests(testGen.tests), 2);


### PR DESCRIPTION
When test are generating for file, function, line, assertion, class or predicate and automatic target is chosen, UTBot selects target that contains the source file