### PR TITLE
fix the bug log cannot send to client sometimes

### DIFF
--- a/server/src/commands/Commands.h
+++ b/server/src/commands/Commands.h
@@ -51,7 +51,7 @@ namespace Commands {
         unsigned int port = 0;
         fs::path logPath;
 
-        loguru::NamedVerbosity verbosity;
+        loguru::NamedVerbosity verbosity = loguru::Verbosity_INFO;
         static const std::map<std::string, loguru::NamedVerbosity> verbosityMap;
     };
 


### PR DESCRIPTION
The type loguru::NamedVerbosity is int in fact,so it has no initialized value when it is defined.It has dirty data where it is in the line 88 in CLIUtils.cpp.This dirty data can cause the log info cannot send to the client sometimes.